### PR TITLE
Retract v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/buildkite/go-pipeline
 
 go 1.21.0
 
+retract v1.0.0 // Published accidentally. We'll skip this version and jump straight to v1.0.1 when we're ready to publish
+
 require (
 	github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251
 	github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,11 @@ module github.com/buildkite/go-pipeline
 
 go 1.21.0
 
-retract v1.0.0 // Published accidentally. We'll skip this version and jump straight to v1.0.1 when we're ready to publish
+retract (
+    v1.0.0 // Published accidentally. 
+    v1.0.1 // Solely to publish the retraction of v1.0.0.
+    // We'll skip straight to v1.0.2 when we're ready to publish
+)
 
 require (
 	github.com/buildkite/interpolate v0.0.0-20200526001904-07f35b4ae251

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/buildkite/go-pipeline
 
-go 1.21.0
+go 1.21
 
 retract (
-    v1.0.0 // Published accidentally. 
-    v1.0.1 // Solely to publish the retraction of v1.0.0.
-    // We'll skip straight to v1.0.2 when we're ready to publish
+	v1.0.1 // Solely to publish the retraction of v1.0.0. We'll skip straight to v1.0.2 when we're ready to publish
+	v1.0.0 // Published accidentally.
 )
 
 require (


### PR DESCRIPTION
i accidentally published v1 when we're not ready, whoops. we'll stay on v0.x until we're stable, then skip straight to v1.0.1