### PR TITLE
Add key.Validate call

### DIFF
--- a/jwkutil/validate.go
+++ b/jwkutil/validate.go
@@ -36,6 +36,10 @@ var (
 // support RS- series signing algorithms for RSA keys, for example
 // It does not check that the key is valid for signing or verifying.
 func Validate(key jwk.Key) error {
+	if err := key.Validate(); err != nil {
+		return err
+	}
+
 	validKeyTypes := []jwa.KeyType{jwa.RSA, jwa.EC, jwa.OctetSeq, jwa.OKP}
 	if !slices.Contains(validKeyTypes, key.KeyType()) {
 		return fmt.Errorf(


### PR DESCRIPTION
This new method was added in https://github.com/lestrrat-go/jwx/releases/tag/v2.0.16, and might not be called automatically.