### PR TITLE
Fix marshalling of plugins without config

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -1153,8 +1153,12 @@ func TestParserParsesScalarPlugins(t *testing.T) {
       "command": "script/buildkite/xxx.sh",
       "name": ":s3: xxx",
       "plugins": [
-        "github.com/buildkite-plugins/example-plugin-buildkite-plugin#v1.0.0",
-        "github.com/buildkite-plugins/another-plugin-buildkite-plugin#v0.0.1-beta43",
+        {
+          "github.com/buildkite-plugins/example-plugin-buildkite-plugin#v1.0.0": null
+        },
+        {
+          "github.com/buildkite-plugins/another-plugin-buildkite-plugin#v0.0.1-beta43": null
+        },
         {
           "github.com/buildkite-plugins/docker-compose-buildkite-plugin#v2.5.1": {
             "config": ".buildkite/docker/docker-compose.yml"

--- a/plugin.go
+++ b/plugin.go
@@ -38,10 +38,6 @@ func (p *Plugin) MarshalJSON() ([]byte, error) {
 // form (no config, only plugin source). Plugin sources are marshalled into "full"
 // form.
 func (p *Plugin) MarshalYAML() (any, error) {
-	if p.Config == nil {
-		return p.FullSource(), nil
-	}
-
 	return map[string]any{
 		p.FullSource(): p.Config,
 	}, nil

--- a/signature/sign_test.go
+++ b/signature/sign_test.go
@@ -64,7 +64,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS256,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzI1NiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..4pYZTwSwJw469ScTf7DzykmO51l-MMFWumA-NpVEZTE",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzI1NiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..wv0pNxPt1hMF6nrMMkARaqsW4q1cQeDFL6IUFfIK8X8",
 		},
 		{
 			name: "HMAC-SHA384",
@@ -72,7 +72,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS384,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzM4NCIsImtpZCI6ImNoYXJ0cmV1c2UifQ..668PsYGv72l8HRY05wp9UBOYqXa1jCsf3OM-XlvwdskL6VsPI_gPnj-M9SyFhLso",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzM4NCIsImtpZCI6ImNoYXJ0cmV1c2UifQ..LJPQY1XPgIUv2d0i3X6EDAuPIOxNH2TGfbIPnyik-uE53okLNP1lD8vMVwOaV6kA",
 		},
 		{
 			name: "HMAC-SHA512",
@@ -80,7 +80,7 @@ func TestSignVerify(t *testing.T) {
 				return jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", alg)
 			},
 			alg:                            jwa.HS512,
-			expectedDeterministicSignature: "eyJhbGciOiJIUzUxMiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..9KgnpPXJUT1C5m5HKsNGP6YeWksxAjeaa3sygWCPho8bsHwSVus8N2gUR_4Ty7Dv9n-r65KMocPMtw3y5coe3Q",
+			expectedDeterministicSignature: "eyJhbGciOiJIUzUxMiIsImtpZCI6ImNoYXJ0cmV1c2UifQ..2diyL2yxtoQuReUiSCunAFL6hpmPYeBv91B96huGqPZ4gqfDDMEO1iL2tk57x3BFXqPgoaSgDGsf19COYnwarA",
 		},
 		{
 			name:           "RSA-PSS 256",


### PR DESCRIPTION
Plugins with no config should be marshalled with a null config. The backend marshalls them from the database into the BUILDKITE_PLUGINS environment variable on a job in this way.