### PR TITLE
Add BaseStep

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -73,7 +73,8 @@ func TestInlineFriendlyMarshalJSON_FailsWhenInlineFieldsIsntAMap(t *testing.T) {
 		t.Fatalf("inlineFriendlyMarshalJSON() == nil, want error")
 	}
 
-	wantError := "inline fields value of pipeline.test.Qux must be a map[string]any, was string instead"
+	// TODO: replace error string test with something more semantic
+	wantError := "could not convert value of field pipeline.test.Qux to map[string]any: could not get fields of string: Cannot use GetField on a non-struct interface"
 	if err.Error() != wantError {
 		t.Errorf("inlineFriendlyMarshalJSON() error = %v, want %v", err, wantError)
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -106,13 +106,15 @@ steps:
 		Steps: Steps{
 			&CommandStep{
 				Command: "docker build .",
-				RemainingFields: map[string]any{
-					"agents": ordered.MapFromItems(
-						ordered.TupleSA{Key: "queue", Value: "default"},
-					),
-					"name":              ":docker: building image",
-					"type":              "script",
-					"agent_query_rules": []any{"queue=default"},
+				BaseStep: BaseStep{
+					RemainingFields: map[string]any{
+						"agents": ordered.MapFromItems(
+							ordered.TupleSA{Key: "queue", Value: "default"},
+						),
+						"name":              ":docker: building image",
+						"type":              "script",
+						"agent_query_rules": []any{"queue=default"},
+					},
 				},
 			},
 		},
@@ -208,13 +210,15 @@ steps:
 		Steps: Steps{
 			&CommandStep{
 				Command: "docker build .",
-				RemainingFields: map[string]any{
-					"agents": ordered.MapFromItems(
-						ordered.TupleSA{Key: "queue", Value: "default"},
-					),
-					"name":              ":docker: building image",
-					"type":              "script",
-					"agent_query_rules": []any{"queue=default"},
+				BaseStep: BaseStep{
+					RemainingFields: map[string]any{
+						"agents": ordered.MapFromItems(
+							ordered.TupleSA{Key: "queue", Value: "default"},
+						),
+						"name":              ":docker: building image",
+						"type":              "script",
+						"agent_query_rules": []any{"queue=default"},
+					},
 				},
 			},
 		},
@@ -588,8 +592,10 @@ func TestParserParsesTopLevelSteps(t *testing.T) {
 		Steps: Steps{
 			&CommandStep{
 				Command: "echo hello world",
-				RemainingFields: map[string]any{
-					"name": "Build",
+				BaseStep: BaseStep{
+					RemainingFields: map[string]any{
+						"name": "Build",
+					},
 				},
 			},
 			&WaitStep{Scalar: "wait"},
@@ -725,8 +731,10 @@ func TestParserPreservesInts(t *testing.T) {
 		Steps: Steps{
 			&CommandStep{
 				Command: "hello",
-				RemainingFields: map[string]any{
-					"parallelism": 10,
+				BaseStep: BaseStep{
+					RemainingFields: map[string]any{
+						"parallelism": 10,
+					},
 				},
 			},
 		},
@@ -935,8 +943,10 @@ steps:
 						},
 					},
 				},
-				RemainingFields: map[string]any{
-					"label": string(":docker: Docker Build"),
+				BaseStep: BaseStep{
+					RemainingFields: map[string]any{
+						"label": string(":docker: Docker Build"),
+					},
 				},
 			},
 		},
@@ -1040,11 +1050,13 @@ steps:
 						},
 					},
 				},
-				RemainingFields: map[string]any{
-					"name": ":s3: xxx",
-					"agents": ordered.MapFromItems(
-						ordered.TupleSA{Key: "queue", Value: "xxx"},
-					),
+				BaseStep: BaseStep{
+					RemainingFields: map[string]any{
+						"name": ":s3: xxx",
+						"agents": ordered.MapFromItems(
+							ordered.TupleSA{Key: "queue", Value: "xxx"},
+						),
+					},
 				},
 			},
 		},
@@ -1133,8 +1145,10 @@ func TestParserParsesScalarPlugins(t *testing.T) {
 						},
 					},
 				},
-				RemainingFields: map[string]any{
-					"name": ":s3: xxx",
+				BaseStep: BaseStep{
+					RemainingFields: map[string]any{
+						"name": ":s3: xxx",
+					},
 				},
 			},
 		},

--- a/step_base.go
+++ b/step_base.go
@@ -1,0 +1,59 @@
+package pipeline
+
+import "github.com/buildkite/go-pipeline/ordered"
+
+// BaseStep models fields common to all step types.
+type BaseStep struct {
+	Key       string   `yaml:"key,omitempty"` // aliases: identifier, id
+	DependsOn []string `yaml:"depends_on,omitempty"`
+
+	// RemainingFields stores any other top-level mapping items so they at least
+	// survive an unmarshal-marshal round-trip.
+	RemainingFields map[string]any `yaml:",inline"`
+}
+
+// UnmarshalOrdered exists to handle aliases for Key.
+func (b *BaseStep) UnmarshalOrdered(src any) error {
+	// Unmarshal into this secret type, then process special fields specially.
+	type wrappedBase BaseStep
+	w := &struct {
+		Key        string `yaml:"key"`
+		ID         string `yaml:"id"`
+		Identifier string `yaml:"identifier"`
+
+		// Use inline trickery to capture the rest of the struct.
+		BaseStep *wrappedBase `yaml:",inline"`
+	}{
+		// Cast b to *wrappedBase to prevent infinite recursion.
+		BaseStep: (*wrappedBase)(b),
+	}
+	if err := ordered.Unmarshal(src, w); err != nil {
+		return err
+	}
+	b.Key = coalesce(w.Key, w.ID, w.Identifier)
+	return nil
+}
+
+func (b *BaseStep) interpolate(tf stringTransformer) error {
+	k, err := tf.Transform(b.Key)
+	if err != nil {
+		return err
+	}
+	b.Key = k
+
+	if err := interpolateSlice(tf, b.DependsOn); err != nil {
+		return err
+	}
+
+	return interpolateMap(tf, b.RemainingFields)
+}
+
+// coalesce returns the first non-empty string, or "" if all args are empty.
+func coalesce(ss ...string) string {
+	for _, s := range ss {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/step_command.go
+++ b/step_command.go
@@ -32,9 +32,7 @@ type CommandStep struct {
 	Signature *Signature        `yaml:"signature,omitempty"`
 	Matrix    *Matrix           `yaml:"matrix,omitempty"`
 
-	// RemainingFields stores any other top-level mapping items so they at least
-	// survive an unmarshal-marshal round-trip.
-	RemainingFields map[string]any `yaml:",inline"`
+	BaseStep BaseStep `yaml:",inline"`
 }
 
 // MarshalJSON marshals the step to JSON. Special handling is needed because
@@ -122,11 +120,7 @@ func (c *CommandStep) interpolate(tf stringTransformer) error {
 
 	// NB: Do not interpolate Signature.
 
-	if err := interpolateMap(tf, c.RemainingFields); err != nil {
-		return err
-	}
-
-	return nil
+	return c.BaseStep.interpolate(tf)
 }
 
 func (CommandStep) stepTag() {}

--- a/step_group.go
+++ b/step_group.go
@@ -13,12 +13,9 @@ type GroupStep struct {
 	// Group is typically a key with no value. Since it must always exist in
 	// a group step, here it is.
 	Group *string `yaml:"group"`
+	Steps Steps   `yaml:"steps"`
 
-	Steps Steps `yaml:"steps"`
-
-	// RemainingFields stores any other top-level mapping items so they at least
-	// survive an unmarshal-marshal round-trip.
-	RemainingFields map[string]any `yaml:",inline"`
+	BaseStep BaseStep `yaml:",inline"`
 }
 
 // UnmarshalOrdered unmarshals a group step from an ordered map.
@@ -45,7 +42,8 @@ func (g *GroupStep) interpolate(tf stringTransformer) error {
 	if err := g.Steps.interpolate(tf); err != nil {
 		return err
 	}
-	return interpolateMap(tf, g.RemainingFields)
+
+	return g.BaseStep.interpolate(tf)
 }
 
 func (GroupStep) stepTag() {}


### PR DESCRIPTION
`BaseStep` replaces `RemainingFields` on `CommandStep` and `GroupStep` as the "inline". It's intended to have fields common to most or all step types, such as `key` and `depends_on`.