### PR TITLE
Add aliases tag and use it

### DIFF
--- a/ordered/unmarshal.go
+++ b/ordered/unmarshal.go
@@ -52,6 +52,11 @@ type Unmarshaler interface {
 //     yaml tags includes ",inline". Inline fields must themselves be a type
 //     that Unmarshal can unmarshal *Map[string, any] into - another struct or
 //     Map or map with string keys.
+//     Struct targets can also have `aliases` tags of the form
+//     `aliases:"apple,banana,citron"`
+//     If the field name or yaml tag key doesn't match, Unmarshal looks through
+//     the aliases list to see if any are present, and uses the value for the
+//     first.
 //   - S = []any (also recursively containing values with types from this list),
 //     which is recursively unmarshaled elementwise; D is *[]any or
 //     *[]somethingElse.
@@ -313,17 +318,30 @@ func (m *Map[K, V]) decodeInto(target any) error {
 		}
 
 		// Is there a value for this key?
-		v, has := tm.Get(key)
+		value, has := tm.Get(key)
 		if !has {
+			// Look for aliases, and choose the first with a value.
+			atag, _ := field.Tag.Lookup("aliases")
+			for _, alias := range strings.Split(atag, ",") {
+				value, has = tm.Get(alias)
+				if has {
+					key = alias
+					break
+				}
+			}
+		}
+		if !has {
+			// Couldn't find a value for the key or any aliases, so skip.
 			continue
 		}
 
-		// Now load v into this field.
+		// key matched a field, so it isn't inline.
 		outlineKeys[key] = struct{}{}
 
+		// Now load value into the field recursively.
 		// Get a pointer to the field. This works because target is a pointer.
 		ptrToField := innerValue.FieldByIndex(field.Index).Addr()
-		if err := Unmarshal(v, ptrToField.Interface()); err != nil {
+		if err := Unmarshal(value, ptrToField.Interface()); err != nil {
 			return err
 		}
 	}

--- a/ordered/unmarshal_test.go
+++ b/ordered/unmarshal_test.go
@@ -81,6 +81,7 @@ type ordinaryStruct struct {
 	Count    int
 	Fader    float64
 	Slicey   []int
+	Alias    string `aliases:"synonym,alternate"`
 	hidden   string
 
 	Next  *ordinaryStruct
@@ -426,6 +427,7 @@ func TestUnmarshal(t *testing.T) {
 				TupleSA{Key: "count", Value: 42},
 				TupleSA{Key: "fader", Value: 2.71828},
 				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+				TupleSA{Key: "synonym", Value: "alias"},
 			),
 			dst: &ordinaryStruct{},
 			want: &ordinaryStruct{
@@ -435,6 +437,7 @@ func TestUnmarshal(t *testing.T) {
 				Count:    42,
 				Fader:    2.71828,
 				Slicey:   []int{5, 6, 7, 8},
+				Alias:    "alias",
 			},
 		},
 		{
@@ -448,6 +451,7 @@ func TestUnmarshal(t *testing.T) {
 				TupleSA{Key: "count", Value: 42},
 				TupleSA{Key: "fader", Value: 2.71828},
 				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+				TupleSA{Key: "alias", Value: "alias"},
 				TupleSA{Key: "notAField", Value: "super important"},
 			),
 			dst: &ordinaryStruct{},
@@ -458,6 +462,7 @@ func TestUnmarshal(t *testing.T) {
 				Count:    42,
 				Fader:    2.71828,
 				Slicey:   []int{5, 6, 7, 8},
+				Alias:    "alias",
 				Remaining: map[string]any{
 					"ignore":    "YOU CANNOT DO THIS!!!",
 					"mountain":  "actually we call them molehills here",
@@ -475,6 +480,7 @@ func TestUnmarshal(t *testing.T) {
 				TupleSA{Key: "count", Value: nil},
 				TupleSA{Key: "fader", Value: 2.71828},
 				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+				TupleSA{Key: "alternate", Value: "Agent Vaughn"},
 				TupleSA{Key: "hidden", Value: "no"},
 				TupleSA{Key: "notAField", Value: "super important"},
 			),
@@ -486,6 +492,7 @@ func TestUnmarshal(t *testing.T) {
 				Count:    69,
 				Fader:    3.14159,
 				Slicey:   []int{1, 2, 3, 4},
+				Alias:    "Sydney Bristow",
 				hidden:   "yes",
 				Remaining: map[string]any{
 					"existing": "wombat",
@@ -499,6 +506,7 @@ func TestUnmarshal(t *testing.T) {
 				Count:    0, // nil becomes a SetZero call
 				Fader:    2.71828,
 				Slicey:   []int{1, 2, 3, 4, 5, 6, 7, 8},
+				Alias:    "Agent Vaughn",
 				hidden:   "yes",
 				Remaining: map[string]any{
 					"existing":  "wombat",
@@ -518,6 +526,7 @@ func TestUnmarshal(t *testing.T) {
 				TupleSA{Key: "fader", Value: 2.71828},
 				TupleSA{Key: "notAField", Value: "super important"},
 				TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+				TupleSA{Key: "alias", Value: "JJ Abrams"},
 				TupleSA{Key: "inner", Value: MapFromItems(
 					TupleSA{Key: "llama", Value: "Kuzco"},
 				)},
@@ -537,6 +546,7 @@ func TestUnmarshal(t *testing.T) {
 				Count:    42,
 				Fader:    2.71828,
 				Slicey:   []int{5, 6, 7, 8},
+				Alias:    "JJ Abrams",
 				Inner:    struct{ Llama string }{"Kuzco"},
 				Next: &ordinaryStruct{
 					Key:      "another value",

--- a/parser_test.go
+++ b/parser_test.go
@@ -105,12 +105,12 @@ steps:
 	want := &Pipeline{
 		Steps: Steps{
 			&CommandStep{
+				Label:   ":docker: building image",
 				Command: "docker build .",
 				RemainingFields: map[string]any{
 					"agents": ordered.MapFromItems(
 						ordered.TupleSA{Key: "queue", Value: "default"},
 					),
-					"name":              ":docker: building image",
 					"type":              "script",
 					"agent_query_rules": []any{"queue=default"},
 				},
@@ -148,7 +148,7 @@ steps:
         "queue": "default"
       },
       "command": "docker build .",
-      "name": ":docker: building image",
+      "label": ":docker: building image",
       "type": "script"
     }
   ]
@@ -207,12 +207,12 @@ steps:
 	want := &Pipeline{
 		Steps: Steps{
 			&CommandStep{
+				Label:   ":docker: building image",
 				Command: "docker build .",
 				RemainingFields: map[string]any{
 					"agents": ordered.MapFromItems(
 						ordered.TupleSA{Key: "queue", Value: "default"},
 					),
-					"name":              ":docker: building image",
 					"type":              "script",
 					"agent_query_rules": []any{"queue=default"},
 				},
@@ -256,7 +256,7 @@ steps:
         "queue": "default"
       },
       "command": "docker build .",
-      "name": ":docker: building image",
+      "label": ":docker: building image",
       "type": "script"
     }
   ]
@@ -588,9 +588,7 @@ func TestParserParsesTopLevelSteps(t *testing.T) {
 		Steps: Steps{
 			&CommandStep{
 				Command: "echo hello world",
-				RemainingFields: map[string]any{
-					"name": "Build",
-				},
+				Label:   "Build",
 			},
 			&WaitStep{Scalar: "wait"},
 		},
@@ -607,7 +605,7 @@ func TestParserParsesTopLevelSteps(t *testing.T) {
   "steps": [
     {
       "command": "echo hello world",
-      "name": "Build"
+      "label": "Build"
     },
     "wait"
   ]
@@ -925,6 +923,7 @@ steps:
 		),
 		Steps: Steps{
 			&CommandStep{
+				Label:   ":docker: Docker Build",
 				Command: "echo foo",
 				Plugins: Plugins{
 					{
@@ -934,9 +933,6 @@ steps:
 							"account_ids": "0123456789",
 						},
 					},
-				},
-				RemainingFields: map[string]any{
-					"label": string(":docker: Docker Build"),
 				},
 			},
 		},
@@ -1013,6 +1009,7 @@ steps:
 	want := &Pipeline{
 		Steps: Steps{
 			&CommandStep{
+				Label:   ":s3: xxx",
 				Command: "script/buildkite/xxx.sh",
 				Plugins: Plugins{
 					{
@@ -1041,7 +1038,6 @@ steps:
 					},
 				},
 				RemainingFields: map[string]any{
-					"name": ":s3: xxx",
 					"agents": ordered.MapFromItems(
 						ordered.TupleSA{Key: "queue", Value: "xxx"},
 					),
@@ -1064,7 +1060,7 @@ steps:
         "queue": "xxx"
       },
       "command": "script/buildkite/xxx.sh",
-      "name": ":s3: xxx",
+      "label": ":s3: xxx",
       "plugins": [
         {
           "github.com/xxx/aws-assume-role-buildkite-plugin#v0.1.0": {
@@ -1118,6 +1114,7 @@ func TestParserParsesScalarPlugins(t *testing.T) {
 	want := &Pipeline{
 		Steps: Steps{
 			&CommandStep{
+				Label:   ":s3: xxx",
 				Command: "script/buildkite/xxx.sh",
 				Plugins: Plugins{
 					{
@@ -1132,9 +1129,6 @@ func TestParserParsesScalarPlugins(t *testing.T) {
 							"config": ".buildkite/docker/docker-compose.yml",
 						},
 					},
-				},
-				RemainingFields: map[string]any{
-					"name": ":s3: xxx",
 				},
 			},
 		},
@@ -1151,7 +1145,7 @@ func TestParserParsesScalarPlugins(t *testing.T) {
   "steps": [
     {
       "command": "script/buildkite/xxx.sh",
-      "name": ":s3: xxx",
+      "label": ":s3: xxx",
       "plugins": [
         {
           "github.com/buildkite-plugins/example-plugin-buildkite-plugin#v1.0.0": null

--- a/step_command.go
+++ b/step_command.go
@@ -59,8 +59,7 @@ func (c *CommandStep) UnmarshalOrdered(src any) error {
 	type wrappedCommand CommandStep
 	// Unmarshal into this secret type, then process special fields specially.
 	fullCommand := new(struct {
-		Command  []string `yaml:"command"`
-		Commands []string `yaml:"commands"`
+		Commands []string `yaml:"commands" aliases:"command"`
 
 		// Use inline trickery to capture the rest of the struct.
 		Rem *wrappedCommand `yaml:",inline"`
@@ -75,8 +74,7 @@ func (c *CommandStep) UnmarshalOrdered(src any) error {
 	// string consistently than it is to pick apart multiple strings
 	// in a consistent way in order to hash all of them
 	// consistently.
-	cmds := append(fullCommand.Command, fullCommand.Commands...)
-	c.Command = strings.Join(cmds, "\n")
+	c.Command = strings.Join(fullCommand.Commands, "\n")
 	return nil
 }
 
@@ -109,7 +107,7 @@ func (c *CommandStep) interpolate(tf stringTransformer) error {
 		if err := interpolateMap(tf, c.Env); err != nil {
 			return err
 		}
-		if c.Matrix, err = interpolateAny(tf, c.Matrix); err != nil {
+		if err := c.Matrix.interpolate(tf); err != nil {
 			return err
 		}
 

--- a/step_group.go
+++ b/step_group.go
@@ -10,9 +10,12 @@ import (
 //
 // Standard caveats apply - see the package comment.
 type GroupStep struct {
-	// Group is typically a key with no value. Since it must always exist in
-	// a group step, here it is.
-	Group *string `yaml:"group"`
+	// Fields common to various step types
+	Key string `yaml:"key,omitempty" aliases:"id,identifier"`
+
+	// Group must always exist in a group step (so that we know it is a group).
+	// If it has a value, it is treated as equivalent to the label or name.
+	Group *string `yaml:"group" aliases:"label,name"`
 
 	Steps Steps `yaml:"steps"`
 
@@ -36,12 +39,12 @@ func (g *GroupStep) UnmarshalOrdered(src any) error {
 }
 
 func (g *GroupStep) interpolate(tf stringTransformer) error {
-	grp, err := interpolateAny(tf, g.Group)
-	if err != nil {
+	if err := interpolateString(tf, &g.Key); err != nil {
 		return err
 	}
-	g.Group = grp
-
+	if err := interpolateString(tf, g.Group); err != nil {
+		return err
+	}
 	if err := g.Steps.interpolate(tf); err != nil {
 		return err
 	}


### PR DESCRIPTION
When configuring a step with YAML, `key`, `id`, and `identifier` keys are synonyms. Similarly, `command` and `commands` are synonyms. This only matters for unmarshaling; when marshaling we have to pick one of them (which we do, via the `yaml` tag). An `aliases` tag might be useful for that.

To demonstrate, I've also added `key` and `label` to `CommandStep` and `GroupStep`.