### PR TITLE
Fix interpolation of command step labels with env variables

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -49,6 +49,51 @@ func TestParserParsesYAML(t *testing.T) {
 	}
 }
 
+func TestParserParsesYAMLWithInterpolationInName(t *testing.T) {
+	env := map[string]string{"ENV_VAR_FRIEND": "friend"}
+	input := strings.NewReader(`
+steps:
+- name: hello-${ENV_VAR_FRIEND}
+  command: echo hello world
+`)
+	got, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse(input) error = %v", err)
+	}
+	if err := got.Interpolate(env); err != nil {
+		t.Fatalf("p.Interpolate(%v) error = %v", env, err)
+	}
+
+	want := &Pipeline{
+		Steps: Steps{
+			&CommandStep{
+				Label:   "hello-friend",
+				Command: "echo hello world",
+			},
+		},
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("parsed pipeline diff (-got, +want):\n%s", diff)
+	}
+
+	gotJSON, err := json.MarshalIndent(got, "", "  ")
+	if err != nil {
+		t.Fatalf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
+	}
+
+	const wantJSON = `{
+  "steps": [
+    {
+      "command": "echo hello world",
+      "label": "hello-friend"
+    }
+  ]
+}`
+	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
+}
+
 func TestParserParsesYAMLWithNoInterpolation(t *testing.T) {
 	input := strings.NewReader("steps:\n  - command: \"hello ${ENV_VAR_FRIEND}\"")
 	got, err := Parse(input)

--- a/parser_test.go
+++ b/parser_test.go
@@ -831,7 +831,7 @@ func TestParserHandlesDates(t *testing.T) {
 
 	llamatime, err := time.Parse(time.RFC3339, timestamp)
 	if err != nil {
-		t.Fatalf("time.Parse(time.RFC3339, %q) errorr = %v", timestamp, err)
+		t.Fatalf("time.Parse(time.RFC3339, %q) error = %v", timestamp, err)
 	}
 	want := &Pipeline{
 		Steps: Steps{

--- a/parser_test.go
+++ b/parser_test.go
@@ -465,6 +465,9 @@ steps:
       - block: goodbye
   - group:
     steps: null
+  - group: Group ${ENV_VAR_FRIEND}
+    id: group-${ENV_VAR_FRIEND}
+    steps: []
 `)
 	got, err := Parse(input)
 	if err != nil {
@@ -485,6 +488,11 @@ steps:
 				},
 			},
 			&GroupStep{
+				Steps: Steps{},
+			},
+			&GroupStep{
+				Key:   "group-friend",
+				Group: ptr("Group friend"),
 				Steps: Steps{},
 			},
 		},
@@ -514,6 +522,11 @@ steps:
     },
     {
       "group": null,
+      "steps": []
+    },
+    {
+      "group": "Group friend",
+      "key": "group-friend",
       "steps": []
     }
   ]

--- a/step_command.go
+++ b/step_command.go
@@ -102,6 +102,9 @@ func (c *CommandStep) interpolate(tf stringTransformer) error {
 	if err := interpolateString(tf, &c.Command); err != nil {
 		return fmt.Errorf("interpolating command: %w", err)
 	}
+	if err := interpolateString(tf, &c.Label); err != nil {
+		return fmt.Errorf("interpolating label: %w", err)
+	}
 	if err := interpolateSlice(tf, c.Plugins); err != nil {
 		return fmt.Errorf("interpolating plugins: %w", err)
 	}

--- a/step_command_test.go
+++ b/step_command_test.go
@@ -113,7 +113,7 @@ func TestStepCommandMatrixInterpolate(t *testing.T) {
 			},
 		},
 		{
-			name: "it interplates environment variable values",
+			name: "it interpolates environment variable values",
 			ms: MatrixPermutation{
 				"name":  "Taylor Launtner",
 				"value": "true",


### PR DESCRIPTION
In https://github.com/buildkite/go-pipeline/pull/11 we moved the `label` (and `name`) field in a command step from the `RemainingFields` to the `Label` field in the `CommandStep` struct. Unfortunately, this meant it was being skipped by the interpolator, both for environment variables (which happens client side) and matrices (which happens server side, so is not affected).

In this PR we add both types of interpolation to the `Label` field. The matrix interpolation should not have any effect because the agent only needs it for verifying signed jobs, and the `label` field is not part of the data that is signed.

That PR also promoted some other fields out of `RemainingFields` in both `CommandStep` and `GroupStep`. I will add tests that interpolation works for these too.