### PR TITLE
Cleanup docs and tests after v0.4.0

### DIFF
--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -207,6 +207,58 @@ func TestInterpolator(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "runtime_env_precedence_order",
+			runtimeEnv: map[string]string{"FOO": "runtime_foo"},
+			input: &Pipeline{
+				Env: ordered.MapFromItems(
+					ordered.TupleSS{Key: "BAR", Value: "$FOO"},
+					ordered.TupleSS{Key: "FOO", Value: "pipeline_foo"},
+				),
+				Steps: Steps{
+					&CommandStep{
+						Command: "echo ${BAR}",
+					},
+				},
+			},
+			expected: &Pipeline{
+				Env: ordered.MapFromItems(
+					ordered.TupleSS{Key: "BAR", Value: "runtime_foo"},
+					ordered.TupleSS{Key: "FOO", Value: "pipeline_foo"},
+				),
+				Steps: Steps{
+					&CommandStep{
+						Command: "echo runtime_foo",
+					},
+				},
+			},
+		},
+		{
+			name:       "runtime_env_precedence_order_2",
+			runtimeEnv: map[string]string{"FOO": "runtime_foo"},
+			input: &Pipeline{
+				Env: ordered.MapFromItems(
+					ordered.TupleSS{Key: "FOO", Value: "pipeline_foo"},
+					ordered.TupleSS{Key: "BAR", Value: "$FOO"},
+				),
+				Steps: Steps{
+					&CommandStep{
+						Command: "echo ${BAR}",
+					},
+				},
+			},
+			expected: &Pipeline{
+				Env: ordered.MapFromItems(
+					ordered.TupleSS{Key: "FOO", Value: "pipeline_foo"},
+					ordered.TupleSS{Key: "BAR", Value: "runtime_foo"},
+				),
+				Steps: Steps{
+					&CommandStep{
+						Command: "echo runtime_foo",
+					},
+				},
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
In my haste to release v0.4.0, I missed some changes I had made to variable names in the documentation.

I've also added the example I wrote in the release notes to the tests.