### PR TITLE
fix: YAML marshaling of wait, block, and input

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/buildkite/go-pipeline/ordered"
 	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
 )
 
 func ptr[T any](x T) *T { return &x }
@@ -642,7 +643,7 @@ steps:
 
 	gotJSON, err := json.MarshalIndent(pipeline, "", "  ")
 	if err != nil {
-		t.Fatalf(`json.MarshalIndent(pipeline, "", "  ") error = %v`, err)
+		t.Errorf(`json.MarshalIndent(pipeline, "", "  ") error = %v`, err)
 	}
 
 	const wantJSON = `{
@@ -656,7 +657,24 @@ steps:
 }`
 
 	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
-		t.Fatalf("marshalled JSON diff (-got +want):\n%s", diff)
+		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
+	}
+
+	gotYAML, err := yaml.Marshal(pipeline)
+	if err != nil {
+		t.Errorf("yaml.Marshal(pipeline) error = %v", err)
+	}
+
+	const wantYAML = `steps:
+    - wait
+    - block
+    - waiter
+    - block
+    - input
+`
+
+	if diff := cmp.Diff(string(gotYAML), wantYAML); diff != "" {
+		t.Errorf("marshalled YAML diff (-got +want):\n%s", diff)
 	}
 }
 

--- a/step_input.go
+++ b/step_input.go
@@ -15,6 +15,8 @@ type InputStep struct {
 	Contents map[string]any `yaml:",inline"`
 }
 
+// MarshalJSON marshals s.Scalar if it's not empty, otherwise s.Contents if that
+// is not empty. If both s.Scalar and s.Contents are empty, it reports an error.
 func (s *InputStep) MarshalJSON() ([]byte, error) {
 	if s.Scalar != "" {
 		return json.Marshal(s.Scalar)
@@ -25,6 +27,18 @@ func (s *InputStep) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(s.Contents)
+}
+
+// MarshalYAML returns s.Scalar if it's not empty, otherwise s.Contents if that
+// is not empty. If both s.Scalar and s.Contents are empty, it reports an error.
+func (s *InputStep) MarshalYAML() (any, error) {
+	if s.Scalar != "" {
+		return s.Scalar, nil
+	}
+	if len(s.Contents) == 0 {
+		return nil, errors.New("empty input step")
+	}
+	return s.Contents, nil
 }
 
 func (s InputStep) interpolate(tf stringTransformer) error {

--- a/step_wait.go
+++ b/step_wait.go
@@ -14,8 +14,8 @@ type WaitStep struct {
 	Contents map[string]any `yaml:",inline"`
 }
 
-// MarshalJSON marshals a wait step as "wait" if w is empty, or as the step's scalar if it's set.
-// If scalar is empty, it marshals as the remaining fields
+// MarshalJSON marshals a wait step as "wait" if the step is empty, or as the
+// s.Scalar if it is not empty, or as s.Contents.
 func (s *WaitStep) MarshalJSON() ([]byte, error) {
 	if s.Scalar != "" {
 		return json.Marshal(s.Scalar)
@@ -26,6 +26,18 @@ func (s *WaitStep) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(s.Contents)
+}
+
+// MarshalYAML returns a wait step as "wait" if the step is empty, or as the
+// s.Scalar if it is not empty, or as s.Contents.
+func (s *WaitStep) MarshalYAML() (any, error) {
+	if s.Scalar != "" {
+		return s.Scalar, nil
+	}
+	if len(s.Contents) == 0 {
+		return "wait", nil
+	}
+	return s.Contents, nil
 }
 
 func (s *WaitStep) interpolate(tf stringTransformer) error {


### PR DESCRIPTION
This is necessary for correct operation of `buildkite-agent tool sign`. Given the input pipeline:

```yaml
steps:
- command: “echo Step 1”
- wait
- command: “echo Step 2”
```

`tool sign` will currently produce:

```yaml
steps:
  - command: “echo Step 1”
    signature:
      ...snip...
  - {}
  - command: “echo Step 2”
    signature:
      ...snip...
```

Note the `{}` where `wait` should be. 

`buildkite-agent pipeline upload` isn't affected by default because it uploads JSON. But `pipeline upload -format=yaml` will also demonstrate this bug. JSON marshaling has plenty of test coverage, but YAML marshaling is barely tested. 
