### PR TITLE
Remove newlines from ordered.Map JSON

### DIFF
--- a/ordered/map.go
+++ b/ordered/map.go
@@ -284,7 +284,6 @@ func (m *Map[K, V]) Range(f func(k K, v V) error) error {
 func (m *Map[K, V]) MarshalJSON() ([]byte, error) {
 	// NB: writes to b don't error, but JSON encoding could error.
 	var b bytes.Buffer
-	enc := json.NewEncoder(&b)
 	b.WriteRune('{')
 	first := true
 	err := m.Range(func(k K, v V) error {
@@ -293,11 +292,18 @@ func (m *Map[K, V]) MarshalJSON() ([]byte, error) {
 			b.WriteRune(',')
 		}
 		first = false
-		if err := enc.Encode(k); err != nil {
+		bk, err := json.Marshal(k)
+		if err != nil {
 			return err
 		}
+		b.Write(bk)
 		b.WriteRune(':')
-		return enc.Encode(v)
+		bv, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		b.Write(bv)
+		return nil
 	})
 	if err != nil {
 		return nil, err

--- a/ordered/map_test.go
+++ b/ordered/map_test.go
@@ -822,3 +822,26 @@ func TestToMapRecursive(t *testing.T) {
 		t.Errorf("ToMapRecursive output diff (-got +want):\n%s", diff)
 	}
 }
+
+func TestMapMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	src := MapFromItems(
+		TupleSA{Key: "key", Value: "value"},
+		TupleSA{Key: "molehill", Value: "large"},
+		TupleSA{Key: "switch", Value: true},
+		TupleSA{Key: "count", Value: 42},
+		TupleSA{Key: "fader", Value: 2.71828},
+		TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+	)
+
+	got, err := src.MarshalJSON()
+	if err != nil {
+		t.Fatalf("src.MarshalJSON() error = %v", err)
+	}
+
+	want := `{"key":"value","molehill":"large","switch":true,"count":42,"fader":2.71828,"slicey":[5,6,7,8]}`
+	if diff := cmp.Diff(string(got), want); diff != "" {
+		t.Errorf("src.MarshalJSON() output diff (-got +want):\n%s", diff)
+	}
+}


### PR DESCRIPTION
`json.Encoder` adds newlines after each encoded object. Most of these never make it to the output, and they should have no effect other than aesthetics, but it feels wrong to leave them in.