### PR TITLE
System for reporting warnings (soft errors)

### DIFF
--- a/ordered/unmarshal.go
+++ b/ordered/unmarshal.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/buildkite/go-pipeline/warning"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -25,6 +27,11 @@ type Unmarshaler interface {
 	// UnmarshalOrdered should unmarshal src into the implementing value. src
 	// will generally be one of *Map[string, any], []any, or a "scalar" built-in
 	// type.
+	// If UnmarshalOrdered returns a non-nil error that is not a warning, the
+	// whole unmarshaling process may halt at that point and report that error
+	// (wrapped).
+	// Unlike other errors, returning a warning lets unmarshalling continue
+	// so that all warnings can be printed together at the end.
 	UnmarshalOrdered(src any) error
 }
 
@@ -157,14 +164,19 @@ func Unmarshal(src, dst any) error {
 				return fmt.Errorf("%w: cannot unmarshal []any into %T", ErrIncompatibleTypes, dst)
 			}
 			etype := sdst.Type().Elem() // E = Type of the slice's elements
-			for _, a := range tsrc {
+			var warns []error
+			for i, a := range tsrc {
 				x := reflect.New(etype) // *E
-				if err := Unmarshal(a, x.Interface()); err != nil {
+				err := Unmarshal(a, x.Interface())
+				if w := warning.As(err); w != nil {
+					warns = append(warns, w.Wrapf("while unmarshaling item %d of %d", i, len(tsrc)))
+				} else if err != nil {
 					return err
 				}
 				sdst = reflect.Append(sdst, x.Elem())
 			}
 			vdst.Elem().Set(sdst)
+			return warning.Wrap(warns...)
 		}
 
 	case string:
@@ -263,14 +275,22 @@ func (m *Map[K, V]) decodeInto(target any) error {
 		}
 
 		valueType := mapType.Elem()
-		return tm.Range(func(k string, v any) error {
+		var warns []error
+		if err := tm.Range(func(k string, v any) error {
 			nv := reflect.New(valueType)
-			if err := Unmarshal(v, nv.Interface()); err != nil {
+			err := Unmarshal(v, nv.Interface())
+			if w := warning.As(err); w != nil {
+				warns = append(warns, w.Wrapf("while unmarshaling value for key %q", k))
+			} else if err != nil {
 				return err
 			}
+
 			innerValue.SetMapIndex(reflect.ValueOf(k), nv.Elem())
 			return nil
-		})
+		}); err != nil {
+			return err
+		}
+		return warning.Wrap(warns...)
 
 	case reflect.Struct:
 		// The rest of the method is concerned with this.
@@ -284,6 +304,8 @@ func (m *Map[K, V]) decodeInto(target any) error {
 
 	var inlineField reflect.StructField
 	outlineKeys := make(map[string]struct{})
+
+	var warns []error
 
 	for _, field := range fields {
 		// Skip non-exported fields. This is conventional *and* correct.
@@ -341,13 +363,16 @@ func (m *Map[K, V]) decodeInto(target any) error {
 		// Now load value into the field recursively.
 		// Get a pointer to the field. This works because target is a pointer.
 		ptrToField := innerValue.FieldByIndex(field.Index).Addr()
-		if err := Unmarshal(value, ptrToField.Interface()); err != nil {
+		err := Unmarshal(value, ptrToField.Interface())
+		if w := warning.As(err); w != nil {
+			warns = append(warns, w.Wrapf("while unmarshaling the value for key %q into struct field %q", key, field.Name))
+		} else if err != nil {
 			return err
 		}
 	}
 
 	if inlineField.Index == nil {
-		return nil
+		return warning.Wrap(warns...)
 	}
 	// The rest is handling the ",inline" field.
 	// We support any field that Unmarshal can unmarshal tm into.
@@ -367,11 +392,19 @@ func (m *Map[K, V]) decodeInto(target any) error {
 
 	// If the inline map contains nothing, then don't bother setting it.
 	if temp.Len() == 0 {
-		return nil
+		return warning.Wrap(warns...)
 	}
 
-	return Unmarshal(temp, inlinePtr.Interface())
+	err := Unmarshal(temp, inlinePtr.Interface())
+	if w := warning.As(err); w != nil {
+		warns = append(warns, w.Wrapf("while unmarshaling the remaining input into an inline field of type %T", inlinePtr.Interface()))
+		return warning.Wrap(warns...)
+	}
+	return err
 }
+
+// Compile-time check that *Map[string,any] is an Unmarshaler
+var _ Unmarshaler = (*MapSA)(nil)
 
 // UnmarshalOrdered unmarshals a value into this map.
 // K must be string, src must be *Map[string, any], and each value in src must
@@ -391,12 +424,19 @@ func (m *Map[K, V]) UnmarshalOrdered(src any) error {
 		return fmt.Errorf("%w: src type %T, want *Map[string, any]", ErrIncompatibleTypes, src)
 	}
 
-	return tsrc.Range(func(k string, v any) error {
+	var warns []error
+	if err := tsrc.Range(func(k string, v any) error {
 		var dv V
-		if err := Unmarshal(v, &dv); err != nil {
+		err := Unmarshal(v, &dv)
+		if w := warning.As(err); w != nil {
+			warns = append(warns, w.Wrapf("while unmarshaling the value for key %q", k))
+		} else if err != nil {
 			return err
 		}
 		tm.Set(k, dv)
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	return warning.Wrap(warns...)
 }

--- a/parser.go
+++ b/parser.go
@@ -10,6 +10,17 @@ import (
 )
 
 // Parse parses a pipeline. It does not apply interpolation.
+// Warnings are passed through the err return:
+//
+//	p, err := Parse(src)
+//	if w := warning.As(err); w != nil {
+//		// Here are some warnings that should be shown
+//		log.Printf("*Warning* - pipeline is not fully parsed:\n%v", w)
+//	} else if err != nil {
+//	    // Parse could not understand src at all
+//	    return err
+//	}
+//	// Use p
 func Parse(src io.Reader) (*Pipeline, error) {
 	// First get yaml.v3 to give us a raw document (*yaml.Node).
 	n := new(yaml.Node)

--- a/step_unknown.go
+++ b/step_unknown.go
@@ -2,7 +2,15 @@ package pipeline
 
 import (
 	"encoding/json"
+
+	"github.com/buildkite/go-pipeline/ordered"
 )
+
+// Compile-time check that *UnknownStep satisfies necessary interfaces
+var _ interface {
+	Step
+	ordered.Unmarshaler
+} = (*UnknownStep)(nil)
 
 // UnknownStep models any step we don't know how to represent in this version.
 // When future step types are added, they should be parsed with more specific
@@ -13,12 +21,12 @@ type UnknownStep struct {
 }
 
 // MarshalJSON marshals the contents of the step.
-func (u UnknownStep) MarshalJSON() ([]byte, error) {
+func (u *UnknownStep) MarshalJSON() ([]byte, error) {
 	return json.Marshal(u.Contents)
 }
 
 // MarshalYAML returns the contents of the step.
-func (u UnknownStep) MarshalYAML() (any, error) {
+func (u *UnknownStep) MarshalYAML() (any, error) {
 	return u.Contents, nil
 }
 

--- a/steps.go
+++ b/steps.go
@@ -1,10 +1,21 @@
 package pipeline
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/buildkite/go-pipeline/ordered"
+	"github.com/buildkite/go-pipeline/warning"
 )
+
+// Sentinel errors that can appear when falling back to UnknownStep.
+var (
+	ErrStepTypeInference = errors.New("cannot infer step type")
+	ErrUnknownStepType   = errors.New("unknown step type")
+)
+
+// Compile-time check that *Steps is an ordered.Unmarshaler.
+var _ ordered.Unmarshaler = (*Steps)(nil)
 
 // Steps contains multiple steps. It is useful for unmarshaling step sequences,
 // since it has custom logic for determining the correct step type.
@@ -27,14 +38,18 @@ func (s *Steps) UnmarshalOrdered(o any) error {
 	if *s == nil {
 		*s = make(Steps, 0, len(sl))
 	}
-	for _, st := range sl {
+
+	var warns []error
+	for i, st := range sl {
 		step, err := unmarshalStep(st)
-		if err != nil {
+		if w := warning.As(err); w != nil {
+			warns = append(warns, w.Wrapf("while unmarshaling step %d of %d", i+1, len(sl)))
+		} else if err != nil {
 			return err
 		}
 		*s = append(*s, step)
 	}
-	return nil
+	return warning.Wrap(warns...)
 }
 
 func (s Steps) interpolate(tf stringTransformer) error {
@@ -45,11 +60,7 @@ func (s Steps) interpolate(tf stringTransformer) error {
 func unmarshalStep(o any) (Step, error) {
 	switch o := o.(type) {
 	case string:
-		step, err := NewScalarStep(o)
-		if err != nil {
-			return &UnknownStep{Contents: o}, nil
-		}
-		return step, nil
+		return NewScalarStep(o)
 
 	case *ordered.MapSA:
 		return stepFromMap(o)
@@ -59,53 +70,78 @@ func unmarshalStep(o any) (Step, error) {
 	}
 }
 
+// stepFromMap parses a step (that was originally a YAML mapping).
 func stepFromMap(o *ordered.MapSA) (Step, error) {
 	sType, hasType := o.Get("type")
 
+	var warns []error
 	var step Step
 	var err error
+
 	if hasType {
 		sTypeStr, ok := sType.(string)
 		if !ok {
 			return nil, fmt.Errorf("unmarshaling step: step's `type` key was %T (value %v), want string", sType, sType)
 		}
-
 		step, err = stepByType(sTypeStr)
-		if err != nil {
-			return nil, fmt.Errorf("unmarshaling step: %w", err)
-		}
 	} else {
 		step, err = stepByKeyInference(o)
-		if err != nil {
-			return nil, fmt.Errorf("unmarshaling step: %w", err)
-		}
+	}
+
+	if err != nil {
+		step = new(UnknownStep)
+		warns = append(warns, err)
 	}
 
 	// Decode the step (into the right step type).
-	if err := ordered.Unmarshal(o, step); err != nil {
+	err = ordered.Unmarshal(o, step)
+	if w := warning.As(err); w != nil {
+		warns = append(warns, w)
+	} else if err != nil {
 		// Hmm, maybe we picked the wrong kind of step?
-		return &UnknownStep{Contents: o}, nil
+		// Downgrade this error to a warning.
+		step = &UnknownStep{Contents: o}
+		warns = append(warns, warning.Wrapf(err, "fell back using unknown type of step due to an unmarshaling error"))
 	}
-	return step, nil
+	return step, warning.Wrap(warns...)
 }
 
+// stepByType returns a new empty step with a type corresponding to the "type"
+// field. Unrecognised type values result in an UnknownStep containing an
+// error wrapping ErrUnknownStepType.
 func stepByType(sType string) (Step, error) {
 	switch sType {
 	case "command", "script":
 		return new(CommandStep), nil
+
 	case "wait", "waiter":
 		return &WaitStep{Contents: map[string]any{}}, nil
+
 	case "block", "input", "manual":
 		return &InputStep{Contents: map[string]any{}}, nil
+
 	case "trigger":
 		return new(TriggerStep), nil
+
 	case "group": // as far as i know this doesn't happen, but it's here for completeness
 		return new(GroupStep), nil
+
 	default:
-		return nil, fmt.Errorf("unknown step type %q", sType)
+		return nil, fmt.Errorf("%w %q", ErrUnknownStepType, sType)
 	}
 }
 
+// stepByType returns a new empty step with a type based on some heuristic rules
+// (first rule wins):
+//
+// - command, commands, plugins -> CommandStep
+// - wait, waiter -> WaitStep
+// - block, input, manual -> InputStep
+// - trigger: TriggerStep
+// - group: GroupStep.
+//
+// Failure to infer a step type results in an UnknownStep containing an
+// error wrapping ErrStepTypeInference.
 func stepByKeyInference(o *ordered.MapSA) (Step, error) {
 	switch {
 	case o.Contains("command") || o.Contains("commands") || o.Contains("plugins"):
@@ -126,6 +162,9 @@ func stepByKeyInference(o *ordered.MapSA) (Step, error) {
 		return new(GroupStep), nil
 
 	default:
-		return new(UnknownStep), nil
+		inferrableKeys := []string{
+			"command", "commands", "plugins", "wait", "waiter", "block", "input", "manual", "trigger", "group",
+		}
+		return nil, fmt.Errorf("%w: need one of %v", ErrStepTypeInference, inferrableKeys)
 	}
 }

--- a/steps.go
+++ b/steps.go
@@ -131,7 +131,8 @@ func stepByType(sType string) (Step, error) {
 	}
 }
 
-// stepByType returns a new empty step with a type based on some heuristic rules
+// stepByKeyInference returns a new empty step with a type based on some heuristic rules
+
 // (first rule wins):
 //
 // - command, commands, plugins -> CommandStep

--- a/warning/warning.go
+++ b/warning/warning.go
@@ -119,7 +119,7 @@ func (w *Warning) Error() string {
 			fmt.Fprintf(b, "%s\n", line)
 		}
 	}
-	return b.String()
+	return strings.TrimSuffix(b.String(), "\n")
 }
 
 // Unwrap returns all errors directly wrapped by this warning.

--- a/warning/warning.go
+++ b/warning/warning.go
@@ -1,0 +1,139 @@
+// Package warning provides a warning error type (a "soft" multi-error).
+//
+// Example usage that catches and produces warnings:
+//
+//	func unmarshalThings(src []any) ([]thing, error) {
+//		var dst []thing
+//		var warns []error
+//		for i, a := range src {
+//			// Unmarshal can produce warnings or errors
+//			var x thing
+//			err := Unmarshal(a, &x)
+//			if w := warning.As(err); w != nil {
+//				warns = append(warns, w.Wrapf("while unmarshaling item %d of %d", i, len(src)))
+//			} else if err != nil {
+//				return err
+//			}
+//			dst = append(dst, x)
+//		}
+//		// Since it only had warnings, return both dst and a wrapper warning.
+//		return dst, warning.Wrap(warns...)
+//	}
+package warning
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Warning is a kind of error that exists so that parsing/processing functions
+// can produce warnings that do not abort part-way, but can still be reported
+// via the error interface and logged.
+// Warning can wrap zero or more errors (that may also be warnings).
+// A Warning with zero wrapped errors is considered equivalent to a nil warning.
+type Warning struct {
+	message string
+	errs    []error
+}
+
+// New creates a new warning that wraps one or more errors. Note that msg is *not* a format string.
+func New(msg string, errs ...error) *Warning { return &Warning{message: msg, errs: errs} }
+
+// Newf creates a new warning that wraps a single error created with fmt.Errorf.
+// (This enables the use of %w for wrapping other errors.)
+func Newf(f string, x ...any) *Warning { return &Warning{errs: []error{fmt.Errorf(f, x...)}} }
+
+// Wrap returns a new warning with no message that wrapps one or more errors.
+// If passed no errors, it returns nil.
+// This is a convenient way to downgrade an error to a warning, and also handle
+// cases where no warnings occurred.
+func Wrap(errs ...error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	return &Warning{errs: errs}
+}
+
+// Wrapf wraps a single error in a warning, with a message created using a format
+// string.
+func Wrapf(err error, f string, x ...any) error {
+	return &Warning{message: fmt.Sprintf(f, x...), errs: []error{err}}
+}
+
+// Is reports if err is a *Warning. nil is not considered to be a warning.
+// This is distinct from errors.Is because an error is a warning only if the top
+// level of the tree is a warning (not if any of the recursively-unwrapped
+// errors are).
+func Is(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*Warning)
+	return ok
+}
+
+// As checks if err is a *Warning, and returns it. If it is nil or not a
+// *Warning, it returns nil.  This is distinct from errors.As because an error
+// is a warning only if the top level of the tree is a warning (not if any of
+// the recursively-unwrapped errors are).
+func As(err error) *Warning {
+	if err == nil {
+		return nil
+	}
+	w, _ := err.(*Warning)
+	return w
+}
+
+// Error returns a string that generally looks like:
+//
+//	w.message
+//	  ↳ w.errs[0].Error()
+//	  ↳ w.errs[1].Error()
+//	  ↳ ...
+//
+// If the warning has no message, it is omitted. If there is no message and also
+// only one child error, that child error's Error() is returned directly.
+// Otherwise, Error prepends indentation to sub-error messages that span
+// multiple lines to make them print nicely.
+func (w *Warning) Error() string {
+	if w.message == "" && len(w.errs) == 1 {
+		return w.errs[0].Error()
+	}
+	b := new(strings.Builder)
+	if w.message != "" {
+		fmt.Fprintln(b, w.message)
+	}
+	for _, err := range w.errs {
+		if err == nil {
+			continue
+		}
+		fmt.Fprint(b, "  ↳ ")
+		for i, line := range strings.Split(err.Error(), "\n") {
+			if i > 0 {
+				fmt.Fprint(b, "    ")
+			}
+			fmt.Fprintf(b, "%s\n", line)
+		}
+	}
+	return b.String()
+}
+
+// Unwrap returns all errors directly wrapped by this warning.
+func (w *Warning) Unwrap() []error { return w.errs }
+
+// Wrapf wraps this warning in a new warning with a message using a format.
+// If w doesn't already have a message, it sets the message and returns w.
+func (w *Warning) Wrapf(f string, x ...any) *Warning {
+	msg := fmt.Sprintf(f, x...)
+	if w.message == "" {
+		w.message = msg
+		return w
+	}
+	return &Warning{message: msg, errs: []error{w}}
+}
+
+// Append appends errs as child errors of this warning.
+func (w *Warning) Append(errs ...error) *Warning {
+	w.errs = append(w.errs, errs...)
+	return w
+}

--- a/warning/warning.go
+++ b/warning/warning.go
@@ -43,13 +43,17 @@ func New(msg string, errs ...error) *Warning { return &Warning{message: msg, err
 // (This enables the use of %w for wrapping other errors.)
 func Newf(f string, x ...any) *Warning { return &Warning{errs: []error{fmt.Errorf(f, x...)}} }
 
-// Wrap returns a new warning with no message that wrapps one or more errors.
+// Wrap returns a new warning with no message that wraps one or more errors.
 // If passed no errors, it returns nil.
+// If passed a single error that is a warning, it returns that warning.
 // This is a convenient way to downgrade an error to a warning, and also handle
 // cases where no warnings occurred.
 func Wrap(errs ...error) error {
 	if len(errs) == 0 {
 		return nil
+	}
+	if len(errs) == 1 && Is(errs[0]) {
+		return errs[0]
 	}
 	return &Warning{errs: errs}
 }


### PR DESCRIPTION
### Description
* Add a new system for reporting soft errors (called _warnings_) through the error interface. 
* Respect warnings in the various layers of the parser: rather than return immediately, accumulate warnings and return them together at the end.
* Add new warnings where some errors were previously dropped when falling back to `UnknownStep`, and where a pipeline is parsed with no steps.

### Background
We have some cases in the parser where, when a failure occurs, parsing continues but producing a pipeline with lower semantic information:

* (Resilience) Maybe this parser has a bug, and we'd rather upload something if there's a chance the backend will accept it than block the user
* (Future compatibility) Maybe we want to introduce a new step type in the future, but allow older agents to continue to upload pipelines without knowing about them

There may be other reasons. These all boil down to "this package is not the authoritative specification for pipeline YAML".

However, silently dropping errors is not great, when they could be used to diagnose why a pipeline isn't being interpreted correctly. Without vigilance, it's easy to write YAML that looks like one thing but is parsed as another. For example:

```yaml
- command: echo hello
  env:
    KEY: {"this_json":"should have been quoted"}
  branches: !main
```

will not parse correctly because
* the `env` block requires strings for values, yet the inline JSON will be parsed as a mapping (this is true here and on the backend)
* `!` has special meaning in YAML when not quoted, so it will end up with `branches: ''`