### PR TITLE
Warnings fix and improvements

### DIFF
--- a/ordered/unmarshal.go
+++ b/ordered/unmarshal.go
@@ -169,9 +169,9 @@ func Unmarshal(src, dst any) error {
 				x := reflect.New(etype) // *E
 				err := Unmarshal(a, x.Interface())
 				if w := warning.As(err); w != nil {
-					warns = append(warns, w.Wrapf("while unmarshaling item %d of %d", i, len(tsrc)))
+					warns = append(warns, w.Wrapf("while unmarshaling item at index %d of %d", i, len(tsrc)))
 				} else if err != nil {
-					return err
+					return fmt.Errorf("unmarshaling item at index %d of %d: %w", i, len(tsrc), err)
 				}
 				sdst = reflect.Append(sdst, x.Elem())
 			}
@@ -282,7 +282,7 @@ func (m *Map[K, V]) decodeInto(target any) error {
 			if w := warning.As(err); w != nil {
 				warns = append(warns, w.Wrapf("while unmarshaling value for key %q", k))
 			} else if err != nil {
-				return err
+				return fmt.Errorf("unmarshaling value for key %q: %w", k, err)
 			}
 
 			innerValue.SetMapIndex(reflect.ValueOf(k), nv.Elem())
@@ -431,7 +431,7 @@ func (m *Map[K, V]) UnmarshalOrdered(src any) error {
 		if w := warning.As(err); w != nil {
 			warns = append(warns, w.Wrapf("while unmarshaling the value for key %q", k))
 		} else if err != nil {
-			return err
+			return fmt.Errorf("unmarshaling value for key %q: %w", k, err)
 		}
 		tm.Set(k, dv)
 		return nil

--- a/pipeline.go
+++ b/pipeline.go
@@ -48,7 +48,9 @@ func (p *Pipeline) UnmarshalOrdered(o any) error {
 	case []any:
 		// A pipeline can be a sequence of steps.
 		err := ordered.Unmarshal(o, &p.Steps)
-		if err != nil {
+		if w := warning.As(err); w != nil {
+			warns = append(warns, w)
+		} else if err != nil {
 			return fmt.Errorf("unmarshaling steps: %w", err)
 		}
 


### PR DESCRIPTION
1. Warnings weren't being handled for top-level steps sequences, this fixes that (with test).
2. Some warnings generated during unmarshaling were not particularly helpful (e.g. complaining about Go types without mentioning what map key it was in) and these can appear in warnings too.  Unmarshaling should provide some signposts ("unmarshaling value for key FOO").

Demo:

```
% buildkite-agent pipeline upload --dry-run <<YAML
heredoc> - command: foo
heredoc>   env:
heredoc>     FOO: {"HELLO": "YES"}
heredoc> YAML
2024-04-03 17:48:57 INFO   Reading pipeline config from STDIN
2024-04-03 17:48:57 WARN   There were some issues with the pipeline input - pipeline upload will proceed, but might not succeed:
while unmarshaling step 1 of 1
  ↳ fell back using unknown type of step due to an unmarshaling error
      ↳ unmarshalling CommandStep: unmarshaling value for key "FOO": incompatible types: cannot unmarshal *ordered.Map[string,interface {}] into *string
{
  "steps": [
    {
      "command": "foo",
      "env": {
        "FOO": {
          "HELLO": "YES"
        }
      }
    }
  ]
}
```