### PR TITLE
Update Go to 1.22

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -6,7 +6,7 @@ steps:
     command: .buildkite/steps/lint.sh
     plugins:
       - docker#v5.9.0:
-          image: "golang:1.21"
+          image: "golang:1.22"
 
   - name: ":go::test_tube: Test"
     key: test
@@ -14,7 +14,7 @@ steps:
     artifact_paths: junit-*.xml
     plugins:
       - docker#v5.9.0:
-          image: "golang:1.21"
+          image: "golang:1.22"
           propagate-environment: true
       - artifacts#v1.9.0:
           upload: "cover.{html,out}"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/buildkite/go-pipeline
 
-go 1.21
+go 1.22
 
-toolchain go1.21.4
+toolchain go1.22.1
 
 retract (
 	v1.0.1 // Solely to publish the retraction of v1.0.0. We'll skip straight to v1.0.2 when we're ready to publish

--- a/interpolate_matrix_test.go
+++ b/interpolate_matrix_test.go
@@ -36,7 +36,6 @@ func TestMatrixInterpolater_Simple(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := transform.Transform(test.input)
@@ -84,7 +83,6 @@ func TestMatrixInterpolater_Multiple(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := transform.Transform(test.input)
@@ -123,7 +121,6 @@ func TestMatrixInterpolator_Errors(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			if _, err := test.transform.Transform(test.input); err == nil {
@@ -237,7 +234,6 @@ func TestMatrixInterpolateAny(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -260,7 +260,6 @@ func TestInterpolator(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/jwkutil/validate_test.go
+++ b/jwkutil/validate_test.go
@@ -54,7 +54,6 @@ func TestValidateJWKDisallows(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/ordered/map_test.go
+++ b/ordered/map_test.go
@@ -71,7 +71,6 @@ func TestMapGet(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -136,7 +135,6 @@ func TestMapSet(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -218,7 +216,6 @@ func TestMapReplace(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -279,7 +276,6 @@ func TestMapDelete(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -342,7 +338,6 @@ func TestMarshalJSON(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			got, err := json.Marshal(test.input)
@@ -384,7 +379,6 @@ func TestToMap(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			got := test.input.ToMap()
@@ -450,7 +444,6 @@ alpaca: drama
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			got, err := yaml.Marshal(test.input)
@@ -654,7 +647,6 @@ d:
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -758,7 +750,6 @@ hello:
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 

--- a/ordered/unmarshal_test.go
+++ b/ordered/unmarshal_test.go
@@ -666,7 +666,6 @@ func TestUnmarshal(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			if err := Unmarshal(test.src, test.dst); err != nil {
@@ -778,7 +777,6 @@ func TestUnmarshalIntoNilErrors(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -858,7 +856,6 @@ func TestUnmarshalIncompatibleTypesErrors(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -888,7 +885,6 @@ func TestUnmarshalNotAPointerErrors(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -978,7 +974,6 @@ func TestMapUnmarshalOrderedErrors(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 

--- a/parser_matrix_test.go
+++ b/parser_matrix_test.go
@@ -432,7 +432,6 @@ steps:
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			got, err := Parse(strings.NewReader(test.input))

--- a/parser_test.go
+++ b/parser_test.go
@@ -523,7 +523,6 @@ steps:
 }`
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -2051,7 +2050,6 @@ steps:
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
 			got, err := Parse(strings.NewReader(test.input))

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -138,7 +138,6 @@ func TestPluginMatrixInterpolate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/signature/sign_test.go
+++ b/signature/sign_test.go
@@ -76,7 +76,6 @@ func TestSignVerify(t *testing.T) {
 
 	keyName := "TEST_DO_NOT_USE"
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -338,7 +337,6 @@ func TestSignVerifyEnv(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			signer, verifier, err := jwkutil.NewSymmetricKeyPairFromString(keyID, "alpacas", jwa.HS256)
@@ -394,7 +392,7 @@ func TestSignatureStability(t *testing.T) {
 
 	// there are n! permutations of n items, but only one is correct
 	// 128! is absurdly large, and we fill four maps...
-	for i := 0; i < 128; i++ {
+	for range 128 {
 		env[fmt.Sprintf("VAR%08x", rand.Uint32())] = fmt.Sprintf("VAL%08x", rand.Uint32())
 		step.Env[fmt.Sprintf("VAR%08x", rand.Uint32())] = fmt.Sprintf("VAL%08x", rand.Uint32())
 		pluginCfg[fmt.Sprintf("key%08x", rand.Uint32())] = fmt.Sprintf("value%08x", rand.Uint32())

--- a/step_command_matrix_test.go
+++ b/step_command_matrix_test.go
@@ -80,7 +80,6 @@ func TestMatrix_ValidatePermutation_Simple(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -183,7 +182,6 @@ func TestMatrix_ValidatePermutation_Multiple(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -220,7 +218,6 @@ func TestMatrix_ValidatePermutation_Nil(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -288,7 +285,6 @@ func TestMatrix_ValidatePermutation_InvalidAdjustment(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			err := test.matrix.validatePermutation(perm)
 			if !errors.Is(err, test.want) {

--- a/step_command_test.go
+++ b/step_command_test.go
@@ -174,7 +174,6 @@ func TestStepCommandMatrixInterpolate(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			tf := newMatrixInterpolator(tc.ms)
 			if err := tc.step.interpolate(tf); err != nil {


### PR DESCRIPTION
### Description

Updates Golang to 1.22, and makes use of the easy-to-convert features it brings. Most notably:
- Makes use of the new [range-over-int](https://tip.golang.org/doc/go1.22#language) technology
  - i used the regex `for (a-z) := 0; (.*); \1\+\+` to find, and then `for $1 := range $2` to replace. Golang then complained that some of the loop variables weren't being used, so i went through those and manually removed the variables that it was complaining about
- Removes redeclarations of loop variables, as they're now scoped to the body of the loop. hooray!
  - i used the regex `(\w+) := \1\n` to find, and replaced with an empty string

(this description stolen from https://github.com/buildkite/agent/pull/2631, but i did do exactly the same thing, so ¯\\\_(ツ)_\/¯)