### PR TITLE
Add Name and Size fields to Cache - COMP-352

### DIFF
--- a/step_command_cache.go
+++ b/step_command_cache.go
@@ -1,12 +1,16 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/buildkite/go-pipeline/ordered"
 )
 
-var _ ordered.Unmarshaler = (*Cache)(nil)
+var _ interface {
+	json.Marshaler
+	ordered.Unmarshaler
+} = (*Cache)(nil)
 
 var (
 	errUnsupportedCacheType = fmt.Errorf("unsupported type for cache")
@@ -14,9 +18,17 @@ var (
 
 // Cache models the cache settings for a given step
 type Cache struct {
-	Paths []string `json:"paths" yaml:"paths"`
+	Name  string   `yaml:"name,omitempty"`
+	Paths []string `yaml:"paths,omitempty"`
+	Size  string   `yaml:"size,omitempty"`
 
 	RemainingFields map[string]any `yaml:",inline"`
+}
+
+// MarshalJSON marshals the step to JSON. Special handling is needed because
+// yaml.v3 has "inline" but encoding/json has no concept of it.
+func (c *Cache) MarshalJSON() ([]byte, error) {
+	return inlineFriendlyMarshalJSON(c)
 }
 
 // UnmarshalOrdered unmarshals from the following types:

--- a/step_command_cache.go
+++ b/step_command_cache.go
@@ -18,9 +18,10 @@ var (
 
 // Cache models the cache settings for a given step
 type Cache struct {
-	Name  string   `yaml:"name,omitempty"`
-	Paths []string `yaml:"paths,omitempty"`
-	Size  string   `yaml:"size,omitempty"`
+	Disabled bool     `yaml:",omitempty"`
+	Name     string   `yaml:"name,omitempty"`
+	Paths    []string `yaml:"paths,omitempty"`
+	Size     string   `yaml:"size,omitempty"`
 
 	RemainingFields map[string]any `yaml:",inline"`
 }
@@ -28,6 +29,9 @@ type Cache struct {
 // MarshalJSON marshals the step to JSON. Special handling is needed because
 // yaml.v3 has "inline" but encoding/json has no concept of it.
 func (c *Cache) MarshalJSON() ([]byte, error) {
+	if c.Disabled {
+		return json.Marshal(false)
+	}
 	return inlineFriendlyMarshalJSON(c)
 }
 
@@ -37,6 +41,10 @@ func (c *Cache) MarshalJSON() ([]byte, error) {
 // - ordered.Map: a map containing paths, among potentially other things
 func (c *Cache) UnmarshalOrdered(o any) error {
 	switch v := o.(type) {
+	case bool:
+		if !v {
+			c.Disabled = true
+		}
 	case string:
 		c.Paths = []string{v}
 

--- a/step_command_cache_test.go
+++ b/step_command_cache_test.go
@@ -50,6 +50,11 @@ func TestCacheMarshalJSON(t *testing.T) {
 			},
 			want: `{"extra":"field","name":"cache-name","paths":["path/to/cache","another/path"],"size":"25g"}`,
 		},
+		{
+			name: "disabled cache",
+			c:    Cache{Disabled: true},
+			want: `false`,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
The agent was uploading pipelines with `name` and `size` fields on `cache` in the `RemainingFields` map which was breaking cache functionality. This has been fixed by implementing the `json.Marshaler` interface for `Cache` and using `inlineFriendlyMarshalJSON` so that `RemainingFields` is correctly inlined.

I've also removed `json:"paths"` from `Cache.Paths` as I don't believe it is required now. Also added `omitempty` to `Cache.Paths` so that it is consistent with everything else.

As suggested by @matthewborden I've also included support for `cache: false`.