### PR TITLE
Revert breaking change to precedence of variables

### DIFF
--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -102,7 +102,7 @@ func TestInterpolator(t *testing.T) {
 				),
 				Steps: Steps{
 					&CommandStep{
-						Command: "echo hello upper_friend",
+						Command: "echo hello lower_friend",
 					},
 				},
 			},
@@ -127,7 +127,7 @@ func TestInterpolator(t *testing.T) {
 				),
 				Steps: Steps{
 					&CommandStep{
-						Command: "echo hello lower_friend",
+						Command: "echo hello upper_friend",
 					},
 				},
 			},
@@ -177,7 +177,7 @@ func TestInterpolator(t *testing.T) {
 				),
 				Steps: Steps{
 					&CommandStep{
-						Command: "echo runtime_baz",
+						Command: "echo pipeline_baz",
 					},
 				},
 			},
@@ -202,7 +202,7 @@ func TestInterpolator(t *testing.T) {
 				),
 				Steps: Steps{
 					&CommandStep{
-						Command: "echo runtime_baz",
+						Command: "echo pipeline_baz",
 					},
 				},
 			},
@@ -250,11 +250,11 @@ func TestInterpolator(t *testing.T) {
 			expected: &Pipeline{
 				Env: ordered.MapFromItems(
 					ordered.TupleSS{Key: "FOO", Value: "pipeline_foo"},
-					ordered.TupleSS{Key: "BAR", Value: "runtime_foo"},
+					ordered.TupleSS{Key: "BAR", Value: "pipeline_foo"},
 				),
 				Steps: Steps{
 					&CommandStep{
-						Command: "echo runtime_foo",
+						Command: "echo pipeline_foo",
 					},
 				},
 			},

--- a/pipeline.go
+++ b/pipeline.go
@@ -105,10 +105,7 @@ func (p *Pipeline) Interpolate(interpolationEnv InterpolationEnv) error {
 // interpolating with the variables defined in interpolationEnv, and then adding the
 // results back into p.Env. Since each environment variable in p.Env can
 // be interpolated into later environment variables, we also add the results
-// to interpolationEnv, but only if interpolationEnv does not already contain that variable
-// as interpolationEnv has precedence over p.Env. For clarification, this means that
-// if a variable name is interpolated to collide with a variable in the
-// interpolationEnv, the interpolationEnv will take precedence.
+// to interpolationEnv, making the input ordering of p.Env potentially important.
 func (p *Pipeline) interpolateEnvBlock(interpolationEnv InterpolationEnv) error {
 	return p.Env.Range(func(k, v string) error {
 		// We interpolate both keys and values.
@@ -125,11 +122,7 @@ func (p *Pipeline) interpolateEnvBlock(interpolationEnv InterpolationEnv) error 
 
 		p.Env.Replace(k, intk, intv)
 
-		// put it into the interpolationEnv for interpolation on a later iteration, but only if it is not
-		// already there, as interpolationEnv has precedence over p.Env
-		if _, exists := interpolationEnv.Get(intk); !exists {
-			interpolationEnv.Set(intk, intv)
-		}
+		interpolationEnv.Set(intk, intv)
 
 		return nil
 	})


### PR DESCRIPTION
In #20 we made a breaking change to always prefer runtime variables over interpolated ones. This means there is now no way to over-write variables set at runtime.

This was a breaking change and if we do change this behaviour it will be done via a major release.