### PR TITLE
Add back preferred runtime env with option

### DIFF
--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -263,7 +263,7 @@ func TestInterpolator(t *testing.T) {
 			t.Parallel()
 
 			runtimeEnv := env.New(env.CaseSensitive(tc.caseSensitive), env.FromMap(tc.runtimeEnv))
-			err := tc.input.Interpolate(runtimeEnv)
+			err := tc.input.Interpolate(runtimeEnv, false)
 			assert.NilError(t, err)
 			if diff := diffPipeline(tc.input, tc.expected); diff != "" {
 				t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/buildkite/go-pipeline/internal/env"
 	"github.com/buildkite/go-pipeline/ordered"
-	"github.com/google/go-cmp/cmp"
 	"gotest.tools/v3/assert"
 )
 
@@ -266,13 +265,9 @@ func TestInterpolator(t *testing.T) {
 			runtimeEnv := env.New(env.CaseSensitive(tc.caseSensitive), env.FromMap(tc.runtimeEnv))
 			err := tc.input.Interpolate(runtimeEnv)
 			assert.NilError(t, err)
-			assert.DeepEqual(
-				t,
-				tc.input,
-				tc.expected,
-				cmp.Comparer(ordered.EqualSA),
-				cmp.Comparer(ordered.EqualSS),
-			)
+			if diff := diffPipeline(tc.input, tc.expected); diff != "" {
+				t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
+			}
 		})
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -12,16 +12,6 @@ import (
 // Options are functional options for creating a new Env.
 type Options func(*Pipeline)
 
-// By default if an environment variable exists in both the runtime and pipeline env
-// we will substitute with the pipeline env IF the pipeline env is defined first.
-// Setting this option to true instead preferres the runtime environment to pipeline
-// environment variables when both are defined.
-func RuntimeEnvPropagation(preferRuntimeEnv bool) Options {
-	return func(e *Pipeline) {
-		e.preferRuntimeEnv = preferRuntimeEnv
-	}
-}
-
 // Parse parses a pipeline. It does not apply interpolation.
 // Warnings are passed through the err return:
 //
@@ -34,7 +24,7 @@ func RuntimeEnvPropagation(preferRuntimeEnv bool) Options {
 //	    return err
 //	}
 //	// Use p
-func Parse(src io.Reader, opts ...Options) (*Pipeline, error) {
+func Parse(src io.Reader) (*Pipeline, error) {
 	// First get yaml.v3 to give us a raw document (*yaml.Node).
 	n := new(yaml.Node)
 	if err := yaml.NewDecoder(src).Decode(n); err != nil {
@@ -49,9 +39,6 @@ func Parse(src io.Reader, opts ...Options) (*Pipeline, error) {
 	// configuration. Then decode _that_ into a pipeline.
 	p := new(Pipeline)
 
-	for _, o := range opts {
-		o(p)
-	}
 	return p, ordered.Unmarshal(n, p)
 }
 

--- a/parser_matrix_test.go
+++ b/parser_matrix_test.go
@@ -438,7 +438,7 @@ steps:
 			if err != nil {
 				t.Fatalf("Parse(%q) error = %v", test.input, err)
 			}
-			if err := got.Interpolate(nil); err != nil {
+			if err := got.Interpolate(nil, false); err != nil {
 				t.Fatalf("Pipeline.Interpolate(nil) = %v", err)
 			}
 			if diff := diffPipeline(got, test.want); diff != "" {

--- a/parser_matrix_test.go
+++ b/parser_matrix_test.go
@@ -441,7 +441,7 @@ steps:
 			if err := got.Interpolate(nil); err != nil {
 				t.Fatalf("Pipeline.Interpolate(nil) = %v", err)
 			}
-			if diff := cmp.Diff(got, test.want, cmp.Comparer(ordered.EqualSS)); diff != "" {
+			if diff := diffPipeline(got, test.want); diff != "" {
 				t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 			}
 			gotJSON, err := json.MarshalIndent(got, "", "  ")

--- a/parser_test.go
+++ b/parser_test.go
@@ -18,7 +18,7 @@ import (
 
 func ptr[T any](x T) *T { return &x }
 
-func diffPipeline(got *Pipeline, want *Pipeline) string { return cmp.Diff(got, want, cmpopts.IgnoreUnexported(*got)) }
+func diffPipeline(got *Pipeline, want *Pipeline) string { return cmp.Diff(got, want, cmpopts.IgnoreUnexported(*got), cmp.Comparer(ordered.EqualSS), cmp.Comparer(ordered.EqualSA)) }
 
 func TestParserParsesYAML(t *testing.T) {
 	runtimeEnv := env.New(env.FromMap(map[string]string{"ENV_VAR_FRIEND": "friend"}))
@@ -36,7 +36,7 @@ func TestParserParsesYAML(t *testing.T) {
 			&CommandStep{Command: "hello friend"},
 		},
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got, +want):\n%s", diff)
 	}
 
@@ -142,7 +142,7 @@ func TestParserParsesYAMLWithNoInterpolation(t *testing.T) {
 			&CommandStep{Command: "hello ${ENV_VAR_FRIEND}"},
 		},
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -216,7 +216,7 @@ steps:
 			),
 		},
 	}
-	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSA)); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -315,7 +315,7 @@ steps:
 			},
 		},
 	}
-	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSA)); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -481,7 +481,7 @@ steps:
 				t.Fatalf("Parse(input) error = %v", err)
 			}
 
-			if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSA)); diff != "" {
+			if diff := diffPipeline(got, want); diff != "" {
 				t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 			}
 
@@ -530,7 +530,7 @@ steps:
 		},
 	}
 
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -568,7 +568,7 @@ func TestParserParsesNoSteps(t *testing.T) {
 		want := &Pipeline{
 			Steps: Steps{},
 		}
-		if diff := cmp.Diff(got, want); diff != "" {
+		if diff := diffPipeline(got, want); diff != "" {
 			t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 		}
 
@@ -640,7 +640,7 @@ steps:
 			},
 		},
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -725,7 +725,7 @@ steps:
 		},
 	}
 
-	if diff := cmp.Diff(pipeline, want); diff != "" {
+	if diff := diffPipeline(pipeline, want); diff != "" {
 		t.Fatalf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -804,7 +804,7 @@ func TestParserParsesJSON(t *testing.T) {
 			&CommandStep{Command: "bye friend"},
 		},
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -853,7 +853,7 @@ func TestParserParsesJSONArrays(t *testing.T) {
 			&CommandStep{Command: "bye friend"},
 		},
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -901,7 +901,7 @@ func TestParserParsesTopLevelSteps(t *testing.T) {
 			&WaitStep{Scalar: "wait"},
 		},
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -995,7 +995,7 @@ steps:
 		},
 	}
 
-	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSA)); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -1074,7 +1074,7 @@ func TestParserEmitsWarningWithTopLevelStepSequence(t *testing.T) {
 		},
 	}
 
-	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSA)); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -1118,7 +1118,7 @@ steps: null
 		Env:   nil,
 		Steps: Steps{},
 	}
-	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSA)); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -1161,7 +1161,7 @@ func TestParserPreservesBools(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -1212,7 +1212,7 @@ func TestParserPreservesInts(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -1258,7 +1258,7 @@ func TestParserPreservesNull(t *testing.T) {
 			&WaitStep{Contents: map[string]any{"wait": nil, "if": "foo"}},
 		},
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -1309,7 +1309,7 @@ func TestParserPreservesFloats(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -1365,7 +1365,7 @@ func TestParserHandlesDates(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -1425,7 +1425,7 @@ func TestParserInterpolatesKeysAsWellAsValues(t *testing.T) {
 			&WaitStep{Scalar: "wait"},
 		},
 	}
-	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSS), cmp.Comparer(ordered.EqualSA)); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 }
@@ -1473,7 +1473,7 @@ steps:
 			},
 		},
 	}
-	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSS), cmp.Comparer(ordered.EqualSA)); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 }
@@ -1510,7 +1510,7 @@ func TestParserLoadsGlobalEnvBlockFirst(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSS), cmp.Comparer(ordered.EqualSA)); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 }
@@ -1581,7 +1581,7 @@ steps:
 			},
 		},
 	}
-	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSA)); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -1698,7 +1698,7 @@ func TestParserParsesScalarPlugins(t *testing.T) {
 			},
 		},
 	}
-	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSA)); diff != "" {
+	if diff := diffPipeline(got, want); diff != "" {
 		t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 	}
 
@@ -1815,7 +1815,7 @@ steps:
 				}
 			}
 
-			if diff := cmp.Diff(got, want); diff != "" {
+			if diff := diffPipeline(got, want); diff != "" {
 				t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 			}
 
@@ -2005,7 +2005,7 @@ steps:
 			if err != nil {
 				t.Fatalf("Parse(%q) error = %v", test.input, err)
 			}
-			if diff := cmp.Diff(got, test.want, cmp.Comparer(ordered.EqualSA)); diff != "" {
+			if diff := diffPipeline(got, test.want); diff != "" {
 				t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
 			}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -12,14 +12,13 @@ import (
 	"github.com/buildkite/go-pipeline/ordered"
 	"github.com/buildkite/go-pipeline/warning"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"gopkg.in/yaml.v3"
 )
 
 func ptr[T any](x T) *T { return &x }
 
 func diffPipeline(got *Pipeline, want *Pipeline) string {
-	return cmp.Diff(got, want, cmpopts.IgnoreUnexported(*got), cmp.Comparer(ordered.EqualSS), cmp.Comparer(ordered.EqualSA))
+	return cmp.Diff(got, want, cmp.Comparer(ordered.EqualSS), cmp.Comparer(ordered.EqualSA))
 }
 
 func TestParserParsesYAML(t *testing.T) {
@@ -29,7 +28,7 @@ func TestParserParsesYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse(input) error = %v", err)
 	}
-	if err := got.Interpolate(runtimeEnv); err != nil {
+	if err := got.Interpolate(runtimeEnv, false); err != nil {
 		t.Fatalf("p.Interpolate(%v) error = %v", runtimeEnv, err)
 	}
 
@@ -166,12 +165,12 @@ steps:
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			got, err := Parse(test.input, RuntimeEnvPropagation(test.runtimePreferred))
+			got, err := Parse(test.input)
 			if err != nil {
 				t.Fatalf("Parse(input) error = %v", err)
 			}
 			runtimeEnv := env.New(env.FromMap(test.runtimeEnv))
-			if err := got.Interpolate(runtimeEnv); err != nil {
+			if err := got.Interpolate(runtimeEnv, test.runtimePreferred); err != nil {
 				t.Fatalf("p.Interpolate(nil) error = %v", err)
 			}
 
@@ -668,7 +667,7 @@ steps:
 	if err != nil {
 		t.Fatalf("Parse(input) error = %v", err)
 	}
-	if err := got.Interpolate(runtimeEnv); err != nil {
+	if err := got.Interpolate(runtimeEnv, false); err != nil {
 		t.Fatalf("p.Interpolate(%v) error = %v", runtimeEnv, err)
 	}
 
@@ -847,7 +846,7 @@ func TestParserParsesJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse(input) error = %v", err)
 	}
-	if err := got.Interpolate(runtimeEnv); err != nil {
+	if err := got.Interpolate(runtimeEnv, false); err != nil {
 		t.Fatalf("p.Interpolate(%v) error = %v", runtimeEnv, err)
 	}
 
@@ -896,7 +895,7 @@ func TestParserParsesJSONArrays(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse(input) error = %v", err)
 	}
-	if err := got.Interpolate(runtimeEnv); err != nil {
+	if err := got.Interpolate(runtimeEnv, false); err != nil {
 		t.Fatalf("p.Interpolate(%v) error = %v", runtimeEnv, err)
 	}
 
@@ -1465,7 +1464,7 @@ func TestParserInterpolatesKeysAsWellAsValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse(input) error = %v", err)
 	}
-	if err := got.Interpolate(runtimeEnv); err != nil {
+	if err := got.Interpolate(runtimeEnv, false); err != nil {
 		t.Fatalf("p.Interpolate(%v) error = %v", runtimeEnv, err)
 	}
 	want := &Pipeline{
@@ -1501,7 +1500,7 @@ steps:
 	if err != nil {
 		t.Fatalf("Parse(input) error = %v", err)
 	}
-	if err := got.Interpolate(runtimeEnv); err != nil {
+	if err := got.Interpolate(runtimeEnv, false); err != nil {
 		t.Fatalf("p.Interpolate(%v) error = %v", runtimeEnv, err)
 	}
 	want := &Pipeline{
@@ -1547,7 +1546,7 @@ func TestParserLoadsGlobalEnvBlockFirst(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse(input) error = %v", err)
 	}
-	if err := got.Interpolate(runtimeEnv); err != nil {
+	if err := got.Interpolate(runtimeEnv, false); err != nil {
 		t.Fatalf("p.Interpolate(%v) error = %v", runtimeEnv, err)
 	}
 	want := &Pipeline{
@@ -1862,7 +1861,7 @@ steps:
 				t.Fatalf("Parse(input) error = %v", err)
 			}
 			if test.interpolate {
-				if err := got.Interpolate(nil); err != nil {
+				if err := got.Interpolate(nil, false); err != nil {
 					t.Fatalf("p.Interpolate(nil) error = %v", err)
 				}
 			}

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -11,10 +12,13 @@ import (
 	"github.com/buildkite/go-pipeline/ordered"
 	"github.com/buildkite/go-pipeline/warning"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gopkg.in/yaml.v3"
 )
 
 func ptr[T any](x T) *T { return &x }
+
+func diffPipeline(got *Pipeline, want *Pipeline) string { return cmp.Diff(got, want, cmpopts.IgnoreUnexported(*got)) }
 
 func TestParserParsesYAML(t *testing.T) {
 	runtimeEnv := env.New(env.FromMap(map[string]string{"ENV_VAR_FRIEND": "friend"}))
@@ -65,119 +69,64 @@ func TestParserParsesYAML(t *testing.T) {
 	}
 }
 
-func TestParserParsesYAMLWithInterpolationInName(t *testing.T) {
-	runtimeEnv := env.New(env.FromMap(map[string]string{"ENV_VAR_FRIEND": "friend"}))
-	input := strings.NewReader(`
+func TestParserParsesYAMLWithInterpolation(t *testing.T) {
+	tests := []struct {
+		desc       string
+		input      io.Reader
+		runtimeEnv map[string]string
+		want       *Pipeline
+	}{
+		{
+			desc:       "InterpolationInName",
+			runtimeEnv: map[string]string{"ENV_VAR_FRIEND": "friend"},
+			input: strings.NewReader(`
 steps:
 - name: hello-${ENV_VAR_FRIEND}
   command: echo hello world
-`)
-	got, err := Parse(input)
-	if err != nil {
-		t.Fatalf("Parse(input) error = %v", err)
-	}
-	if err := got.Interpolate(runtimeEnv); err != nil {
-		t.Fatalf("p.Interpolate(%v) error = %v", runtimeEnv, err)
-	}
-
-	want := &Pipeline{
-		Steps: Steps{
-			&CommandStep{
-				Label:   "hello-friend",
-				Command: "echo hello world",
+`),
+			want: &Pipeline{
+				Steps: Steps{
+					&CommandStep{
+						Label:   "hello-friend",
+						Command: "echo hello world",
+					},
+				},
 			},
 		},
-	}
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("parsed pipeline diff (-got, +want):\n%s", diff)
-	}
-
-	gotJSON, err := json.MarshalIndent(got, "", "  ")
-	if err != nil {
-		t.Errorf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
-	}
-
-	const wantJSON = `{
-  "steps": [
-    {
-      "command": "echo hello world",
-      "label": "hello-friend"
-    }
-  ]
-}`
-	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
-		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
-	}
-
-	gotYAML, err := yaml.Marshal(got)
-	if err != nil {
-		t.Errorf("yaml.Marshal(got) error = %v", err)
-	}
-
-	wantYAML := `steps:
-    - label: hello-friend
-      command: echo hello world
-`
-	if diff := cmp.Diff(string(gotYAML), wantYAML); diff != "" {
-		t.Errorf("marshalled YAML diff (-got +want):\n%s", diff)
-	}
-}
-
-func TestParserParsesYAMLWithInterpolationInKey(t *testing.T) {
-	runtimeEnv := env.New(env.FromMap(map[string]string{"ENV_VAR_FRIEND": "friend"}))
-	input := strings.NewReader(`
+		{
+			desc:       "InterpolationInKey",
+			input:      strings.NewReader(`
 steps:
 - key: hello-${ENV_VAR_FRIEND}
   command: echo hello world
-`)
-	got, err := Parse(input)
-	if err != nil {
-		t.Fatalf("Parse(input) error = %v", err)
-	}
-	if err := got.Interpolate(runtimeEnv); err != nil {
-		t.Fatalf("p.Interpolate(%v) error = %v", runtimeEnv, err)
-	}
-
-	want := &Pipeline{
-		Steps: Steps{
-			&CommandStep{
-				Key:     "hello-friend",
-				Command: "echo hello world",
+`),
+			runtimeEnv: map[string]string{"ENV_VAR_FRIEND": "friend"},
+			want:       &Pipeline{
+				Steps: Steps{
+					&CommandStep{
+						Key:     "hello-friend",
+						Command: "echo hello world",
+					},
+				},
 			},
 		},
 	}
-	if diff := cmp.Diff(got, want); diff != "" {
-		t.Errorf("parsed pipeline diff (-got, +want):\n%s", diff)
-	}
 
-	gotJSON, err := json.MarshalIndent(got, "", "  ")
-	if err != nil {
-		t.Errorf(`json.MarshalIndent(got, "", "  ") error = %v`, err)
-	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			got, err := Parse(test.input)
+			if err != nil {
+				t.Fatalf("Parse(input) error = %v", err)
+			}
+			runtimeEnv := env.New(env.FromMap(test.runtimeEnv))
+			if err := got.Interpolate(runtimeEnv); err != nil {
+				t.Fatalf("p.Interpolate(nil) error = %v", err)
+			}
 
-	const wantJSON = `{
-  "steps": [
-    {
-      "command": "echo hello world",
-      "key": "hello-friend"
-    }
-  ]
-}`
-	if diff := cmp.Diff(string(gotJSON), wantJSON); diff != "" {
-		t.Errorf("marshalled JSON diff (-got +want):\n%s", diff)
-	}
-
-	gotYAML, err := yaml.Marshal(got)
-	if err != nil {
-		t.Errorf("yaml.Marshal(got) error = %v", err)
-	}
-
-	wantYAML := `steps:
-    - key: hello-friend
-      command: echo hello world
-`
-	if diff := cmp.Diff(string(gotYAML), wantYAML); diff != "" {
-		t.Errorf("marshalled YAML diff (-got +want):\n%s", diff)
+			if diff := diffPipeline(got, test.want); diff != "" {
+				t.Errorf("parsed pipeline diff (-got +want):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -80,7 +80,6 @@ type InterpolationEnv interface {
 //     conflict, to apply later.
 //   - Interpolate any string value in the rest of the pipeline.
 //
-// /
 // By default if an environment variable exists in both the runtime and pipeline env
 // we will substitute with the pipeline env IF the pipeline env is defined first.
 // Setting the preferRuntimeEnv option to true instead prefers the runtime environment to pipeline

--- a/pipeline.go
+++ b/pipeline.go
@@ -19,6 +19,8 @@ type Pipeline struct {
 	// RemainingFields stores any other top-level mapping items so they at least
 	// survive an unmarshal-marshal round-trip.
 	RemainingFields map[string]any `yaml:",inline"`
+
+	preferRuntimeEnv bool `yaml:",omitempty"`
 }
 
 // MarshalJSON marshals a pipeline to JSON. Special handling is needed because
@@ -122,7 +124,10 @@ func (p *Pipeline) interpolateEnvBlock(interpolationEnv InterpolationEnv) error 
 
 		p.Env.Replace(k, intk, intv)
 
-		interpolationEnv.Set(intk, intv)
+		// If the variable already existed and we prefer the runtime environment then don't overwrite it
+		if _, exists := interpolationEnv.Get(intk); !(p.preferRuntimeEnv && exists) {
+			interpolationEnv.Set(intk, intv)
+		}
 
 		return nil
 	})

--- a/pipeline.go
+++ b/pipeline.go
@@ -19,8 +19,6 @@ type Pipeline struct {
 	// RemainingFields stores any other top-level mapping items so they at least
 	// survive an unmarshal-marshal round-trip.
 	RemainingFields map[string]any `yaml:",inline"`
-
-	preferRuntimeEnv bool `yaml:",omitempty"`
 }
 
 // MarshalJSON marshals a pipeline to JSON. Special handling is needed because
@@ -81,14 +79,20 @@ type InterpolationEnv interface {
 //   - Interpolate pipeline.Env and copy the results into interpolationEnv, provided they don't
 //     conflict, to apply later.
 //   - Interpolate any string value in the rest of the pipeline.
-func (p *Pipeline) Interpolate(interpolationEnv InterpolationEnv) error {
+//
+// /
+// By default if an environment variable exists in both the runtime and pipeline env
+// we will substitute with the pipeline env IF the pipeline env is defined first.
+// Setting the preferRuntimeEnv option to true instead prefers the runtime environment to pipeline
+// environment variables when both are defined.
+func (p *Pipeline) Interpolate(interpolationEnv InterpolationEnv, preferRuntimeEnv bool) error {
 	if interpolationEnv == nil {
 		interpolationEnv = env.New()
 	}
 
 	// Preprocess any env that are defined in the top level block and place them
 	// into env for later interpolation into the rest of the pipeline.
-	if err := p.interpolateEnvBlock(interpolationEnv); err != nil {
+	if err := p.interpolateEnvBlock(interpolationEnv, preferRuntimeEnv); err != nil {
 		return err
 	}
 
@@ -108,7 +112,7 @@ func (p *Pipeline) Interpolate(interpolationEnv InterpolationEnv) error {
 // results back into p.Env. Since each environment variable in p.Env can
 // be interpolated into later environment variables, we also add the results
 // to interpolationEnv, making the input ordering of p.Env potentially important.
-func (p *Pipeline) interpolateEnvBlock(interpolationEnv InterpolationEnv) error {
+func (p *Pipeline) interpolateEnvBlock(interpolationEnv InterpolationEnv, preferRuntimeEnv bool) error {
 	return p.Env.Range(func(k, v string) error {
 		// We interpolate both keys and values.
 		intk, err := interpolate.Interpolate(interpolationEnv, k)
@@ -125,7 +129,7 @@ func (p *Pipeline) interpolateEnvBlock(interpolationEnv InterpolationEnv) error 
 		p.Env.Replace(k, intk, intv)
 
 		// If the variable already existed and we prefer the runtime environment then don't overwrite it
-		if _, exists := interpolationEnv.Get(intk); !(p.preferRuntimeEnv && exists) {
+		if _, exists := interpolationEnv.Get(intk); !(preferRuntimeEnv && exists) {
 			interpolationEnv.Set(intk, intv)
 		}
 


### PR DESCRIPTION
In #35 we reverted a breaking change to the way we interpolate environment variables.
This PR adds a flag to optionally enable the functionality that was introduced in v0.4.0.

Instead of adding back the tests I undid in #35 I opted to add new tests in `parser_test.go`, which is where this functionality exists, interpolate just does the interpolation, `pipeline.go` decides the precedence of variables.