### PR TITLE
Log public key fingerprint in debug, log step payload in signing-debug

### DIFF
--- a/signature/sign.go
+++ b/signature/sign.go
@@ -117,17 +117,15 @@ func Sign(key jwk.Key, sf SignedFielder, opts ...Option) (*pipeline.Signature, e
 		return nil, err
 	}
 
-	if options.logger != nil {
-		if pk, err := key.PublicKey(); err == nil {
-			fingerprint, err := pk.Thumbprint(crypto.SHA256)
-			if err != nil {
-				return nil, fmt.Errorf("calculating key thumbprint: %w", err)
-			} else {
-				debug(options.logger, "Public Key Thumbprint (sha256): %s", hex.EncodeToString(fingerprint))
-			}
-		} else if err != nil {
-			debug(options.logger, "unable to generate public key: %s", err)
+	if pk, err := key.PublicKey(); err == nil && options.logger != nil {
+		fingerprint, err := pk.Thumbprint(crypto.SHA256)
+		if err != nil {
+			return nil, fmt.Errorf("calculating key thumbprint: %w", err)
+		} else {
+			debug(options.logger, "Public Key Thumbprint (sha256): %s", hex.EncodeToString(fingerprint))
 		}
+	} else if err != nil {
+		return nil, fmt.Errorf("unable to generate public key: %w", err)
 	}
 
 	if options.debugSigning {

--- a/signature/sign.go
+++ b/signature/sign.go
@@ -62,13 +62,20 @@ func WithEnv(env map[string]string) Option      { return envOption{env} }
 func WithLogger(logger Logger) Option           { return loggerOption{logger} }
 func WithDebugSigning(debugSigning bool) Option { return debugSigningOption{debugSigning} }
 
-// Sign computes a new signature for an environment (env) combined with an
-// object containing values (sf) using a given key.
-func Sign(key jwk.Key, sf SignedFielder, opts ...Option) (*pipeline.Signature, error) {
-	options := options{env: make(map[string]string)}
+func configureOptions(opts ...Option) options {
+	options := options{
+		env: make(map[string]string),
+	}
 	for _, o := range opts {
 		o.apply(&options)
 	}
+	return options
+}
+
+// Sign computes a new signature for an environment (env) combined with an
+// object containing values (sf) using a given key.
+func Sign(key jwk.Key, sf SignedFielder, opts ...Option) (*pipeline.Signature, error) {
+	options := configureOptions(opts...)
 
 	values, err := sf.SignedFields()
 	if err != nil {
@@ -141,10 +148,7 @@ func Sign(key jwk.Key, sf SignedFielder, opts ...Option) (*pipeline.Signature, e
 // Verify verifies an existing signature against environment (env) combined with
 // an object containing values (sf) using keys from a keySet.
 func Verify(s *pipeline.Signature, keySet jwk.Set, sf SignedFielder, opts ...Option) error {
-	options := options{env: make(map[string]string)}
-	for _, o := range opts {
-		o.apply(&options)
-	}
+	options := configureOptions(opts...)
 
 	if len(s.SignedFields) == 0 {
 		return errors.New("signature covers no fields")

--- a/signature/sign.go
+++ b/signature/sign.go
@@ -105,15 +105,17 @@ func Sign(key jwk.Key, sf SignedFielder, opts ...Option) (*pipeline.Signature, e
 		return nil, err
 	}
 
-	if pk, err := key.PublicKey(); err == nil && options.logger != nil {
-		fingerprint, err := pk.Thumbprint(crypto.SHA256)
-		if err != nil {
-			return nil, fmt.Errorf("calculating key thumbprint: %w", err)
-		} else {
-			debug(options.logger, "Public Key Thumbprint (sha256): %s", hex.EncodeToString(fingerprint))
+	if options.logger != nil {
+		if pk, err := key.PublicKey(); err == nil {
+			fingerprint, err := pk.Thumbprint(crypto.SHA256)
+			if err != nil {
+				return nil, fmt.Errorf("calculating key thumbprint: %w", err)
+			} else {
+				debug(options.logger, "Public Key Thumbprint (sha256): %s", hex.EncodeToString(fingerprint))
+			}
+		} else if err != nil {
+			debug(options.logger, "unable to generate public key: %s", err)
 		}
-	} else if err != nil {
-		return nil, fmt.Errorf("unable to generate public key: %w", err)
 	}
 
 	if options.debugSigning {

--- a/signature/sign.go
+++ b/signature/sign.go
@@ -110,7 +110,7 @@ func Sign(key jwk.Key, sf SignedFielder, opts ...Option) (*pipeline.Signature, e
 		if err != nil {
 			debug(options.logger, "Cannot calculate key thumbprint")
 		} else {
-			debug(options.logger, "Public Key Thumbprint: %s", hex.EncodeToString(fingerprint))
+			debug(options.logger, "Public Key Thumbprint (sha256): %s", hex.EncodeToString(fingerprint))
 		}
 	} else {
 		debug(options.logger, "Unable to generate public key")
@@ -189,7 +189,7 @@ func Verify(s *pipeline.Signature, keySet jwk.Set, sf SignedFielder, opts ...Opt
 			if err != nil {
 				debug(options.logger, "Cannot calculate key thumbprint")
 			} else {
-				debug(options.logger, "Public Key Thumbprint: %s", hex.EncodeToString(fingerprint))
+				debug(options.logger, "Public Key Thumbprint (sha256): %s", hex.EncodeToString(fingerprint))
 			}
 		}
 	}

--- a/signature/sign_test.go
+++ b/signature/sign_test.go
@@ -96,7 +96,7 @@ func TestSignVerify(t *testing.T) {
 				t.Fatalf("jwkutil.LoadKey(%v, %v) error = %v", privPath, keyName, err)
 			}
 
-			sig, err := Sign(sKey, signEnv, stepWithInvariants)
+			sig, err := Sign(sKey, signEnv, stepWithInvariants, nil)
 			if err != nil {
 				t.Fatalf("Sign(CommandStep, signer) error = %v", err)
 			}
@@ -122,7 +122,7 @@ func TestSignVerify(t *testing.T) {
 				t.Fatalf("verifier.AddKey(%v) error = %v", vKey, err)
 			}
 
-			if err := Verify(sig, verifier, verifyEnv, stepWithInvariants); err != nil {
+			if err := Verify(sig, verifier, verifyEnv, stepWithInvariants, nil); err != nil {
 				t.Errorf("Verify(sig,CommandStep, verifier) = %v", err)
 			}
 		})
@@ -183,7 +183,7 @@ func TestSignConcatenatedFields(t *testing.T) {
 	}
 
 	for _, m := range maps {
-		sig, err := Sign(key, nil, m)
+		sig, err := Sign(key, nil, m, nil)
 		if err != nil {
 			t.Fatalf("Sign(%v, pts) error = %v", m, err)
 		}
@@ -221,6 +221,7 @@ func TestUnknownAlgorithm(t *testing.T) {
 		key,
 		nil,
 		&CommandStepWithInvariants{CommandStep: pipeline.CommandStep{Command: "llamas"}},
+		nil,
 	); err == nil {
 		t.Errorf("Sign(nil, CommandStep, signer) = %v, want non-nil error", err)
 	}
@@ -242,7 +243,7 @@ func TestVerifyBadSignature(t *testing.T) {
 		t.Fatalf("NewSymmetricKeyPairFromString(alpacas) error = %v", err)
 	}
 
-	if err := Verify(sig, verifier, nil, cs); err == nil {
+	if err := Verify(sig, verifier, nil, cs, nil); err == nil {
 		t.Errorf("Verify(sig,CommandStep, alpacas) = %v, want non-nil error", err)
 	}
 }
@@ -266,7 +267,7 @@ func TestSignUnknownStep(t *testing.T) {
 		t.Fatalf("signer.Key(0) = _, false, want true")
 	}
 
-	if err := SignSteps(steps, key, nil, ""); !errors.Is(err, errSigningRefusedUnknownStepType) {
+	if err := SignSteps(steps, key, nil, "", nil); !errors.Is(err, errSigningRefusedUnknownStepType) {
 		t.Errorf("steps.sign(signer) = %v, want %v", err, errSigningRefusedUnknownStepType)
 	}
 }
@@ -354,12 +355,12 @@ func TestSignVerifyEnv(t *testing.T) {
 				RepositoryURL: tc.repositoryURL,
 			}
 
-			sig, err := Sign(key, tc.pipelineEnv, stepWithInvariants)
+			sig, err := Sign(key, tc.pipelineEnv, stepWithInvariants, nil)
 			if err != nil {
 				t.Fatalf("Sign(CommandStep, signer) error = %v", err)
 			}
 
-			if err := Verify(sig, verifier, tc.verifyEnv, stepWithInvariants); err != nil {
+			if err := Verify(sig, verifier, tc.verifyEnv, stepWithInvariants, nil); err != nil {
 				t.Errorf("Verify(sig,CommandStep, verifier) = %v", err)
 			}
 		})
@@ -409,12 +410,12 @@ func TestSignatureStability(t *testing.T) {
 		t.Fatalf("signer.Key(0) = _, false, want true")
 	}
 
-	sig, err := Sign(key, env, stepWithInvariants)
+	sig, err := Sign(key, env, stepWithInvariants, nil)
 	if err != nil {
 		t.Fatalf("Sign(env, CommandStep, signer) error = %v", err)
 	}
 
-	if err := Verify(sig, verifier, env, stepWithInvariants); err != nil {
+	if err := Verify(sig, verifier, env, stepWithInvariants, nil); err != nil {
 		t.Errorf("Verify(sig,env, CommandStep, verifier) = %v", err)
 	}
 }

--- a/signature/sign_test.go
+++ b/signature/sign_test.go
@@ -96,7 +96,7 @@ func TestSignVerify(t *testing.T) {
 				t.Fatalf("jwkutil.LoadKey(%v, %v) error = %v", privPath, keyName, err)
 			}
 
-			sig, err := Sign(sKey, signEnv, stepWithInvariants, nil)
+			sig, err := Sign(sKey, stepWithInvariants, WithEnv(signEnv))
 			if err != nil {
 				t.Fatalf("Sign(CommandStep, signer) error = %v", err)
 			}
@@ -122,7 +122,7 @@ func TestSignVerify(t *testing.T) {
 				t.Fatalf("verifier.AddKey(%v) error = %v", vKey, err)
 			}
 
-			if err := Verify(sig, verifier, verifyEnv, stepWithInvariants, nil); err != nil {
+			if err := Verify(sig, verifier, stepWithInvariants, WithEnv(verifyEnv)); err != nil {
 				t.Errorf("Verify(sig,CommandStep, verifier) = %v", err)
 			}
 		})
@@ -183,7 +183,7 @@ func TestSignConcatenatedFields(t *testing.T) {
 	}
 
 	for _, m := range maps {
-		sig, err := Sign(key, nil, m, nil)
+		sig, err := Sign(key, m)
 		if err != nil {
 			t.Fatalf("Sign(%v, pts) error = %v", m, err)
 		}
@@ -219,9 +219,7 @@ func TestUnknownAlgorithm(t *testing.T) {
 
 	if _, err := Sign(
 		key,
-		nil,
 		&CommandStepWithInvariants{CommandStep: pipeline.CommandStep{Command: "llamas"}},
-		nil,
 	); err == nil {
 		t.Errorf("Sign(nil, CommandStep, signer) = %v, want non-nil error", err)
 	}
@@ -243,7 +241,7 @@ func TestVerifyBadSignature(t *testing.T) {
 		t.Fatalf("NewSymmetricKeyPairFromString(alpacas) error = %v", err)
 	}
 
-	if err := Verify(sig, verifier, nil, cs, nil); err == nil {
+	if err := Verify(sig, verifier, cs); err == nil {
 		t.Errorf("Verify(sig,CommandStep, alpacas) = %v, want non-nil error", err)
 	}
 }
@@ -267,7 +265,7 @@ func TestSignUnknownStep(t *testing.T) {
 		t.Fatalf("signer.Key(0) = _, false, want true")
 	}
 
-	if err := SignSteps(steps, key, nil, "", nil); !errors.Is(err, errSigningRefusedUnknownStepType) {
+	if err := SignSteps(steps, key, ""); !errors.Is(err, errSigningRefusedUnknownStepType) {
 		t.Errorf("steps.sign(signer) = %v, want %v", err, errSigningRefusedUnknownStepType)
 	}
 }
@@ -355,12 +353,12 @@ func TestSignVerifyEnv(t *testing.T) {
 				RepositoryURL: tc.repositoryURL,
 			}
 
-			sig, err := Sign(key, tc.pipelineEnv, stepWithInvariants, nil)
+			sig, err := Sign(key, stepWithInvariants, WithEnv(tc.pipelineEnv))
 			if err != nil {
 				t.Fatalf("Sign(CommandStep, signer) error = %v", err)
 			}
 
-			if err := Verify(sig, verifier, tc.verifyEnv, stepWithInvariants, nil); err != nil {
+			if err := Verify(sig, verifier, stepWithInvariants, WithEnv(tc.verifyEnv)); err != nil {
 				t.Errorf("Verify(sig,CommandStep, verifier) = %v", err)
 			}
 		})
@@ -410,12 +408,12 @@ func TestSignatureStability(t *testing.T) {
 		t.Fatalf("signer.Key(0) = _, false, want true")
 	}
 
-	sig, err := Sign(key, env, stepWithInvariants, nil)
+	sig, err := Sign(key, stepWithInvariants, WithEnv(env))
 	if err != nil {
 		t.Fatalf("Sign(env, CommandStep, signer) error = %v", err)
 	}
 
-	if err := Verify(sig, verifier, env, stepWithInvariants, nil); err != nil {
+	if err := Verify(sig, verifier, stepWithInvariants, WithEnv(env)); err != nil {
 		t.Errorf("Verify(sig,env, CommandStep, verifier) = %v", err)
 	}
 }

--- a/signature/steps.go
+++ b/signature/steps.go
@@ -12,7 +12,12 @@ var errSigningRefusedUnknownStepType = errors.New("refusing to sign pipeline con
 
 // SignSteps adds signatures to each command step (and recursively to any command steps that are within group steps).
 // The steps are mutated directly, so an error part-way through may leave some steps un-signed.
-func SignSteps(s pipeline.Steps, key jwk.Key, env map[string]string, repoURL string, logger Logger) error {
+func SignSteps(s pipeline.Steps, key jwk.Key, repoURL string, opts ...Option) error {
+	options := options{env: make(map[string]string)}
+	for _, o := range opts {
+		o.apply(&options)
+	}
+
 	for _, step := range s {
 		switch step := step.(type) {
 		case *pipeline.CommandStep:
@@ -21,14 +26,14 @@ func SignSteps(s pipeline.Steps, key jwk.Key, env map[string]string, repoURL str
 				RepositoryURL: repoURL,
 			}
 
-			sig, err := Sign(key, env, stepWithInvariants, logger)
+			sig, err := Sign(key, stepWithInvariants, opts...)
 			if err != nil {
 				return fmt.Errorf("signing step with command %q: %w", step.Command, err)
 			}
 			step.Signature = sig
 
 		case *pipeline.GroupStep:
-			if err := SignSteps(step.Steps, key, env, repoURL, logger); err != nil {
+			if err := SignSteps(step.Steps, key, repoURL, opts...); err != nil {
 				return fmt.Errorf("signing group step: %w", err)
 			}
 
@@ -46,7 +51,7 @@ func SignSteps(s pipeline.Steps, key jwk.Key, env map[string]string, repoURL str
 
 // SignPipeline adds signatures to each command step (and recursively to any command steps that are within group steps) within a pipeline
 func SignPipeline(p *pipeline.Pipeline, key jwk.Key, repo string, logger Logger) error {
-	if err := SignSteps(p.Steps, key, p.Env.ToMap(), repo, logger); err != nil {
+	if err := SignSteps(p.Steps, key, repo, WithEnv(p.Env.ToMap()), WithLogger(logger)); err != nil {
 		return fmt.Errorf("signing steps: %w", err)
 	}
 	return nil

--- a/signature/steps.go
+++ b/signature/steps.go
@@ -13,11 +13,6 @@ var errSigningRefusedUnknownStepType = errors.New("refusing to sign pipeline con
 // SignSteps adds signatures to each command step (and recursively to any command steps that are within group steps).
 // The steps are mutated directly, so an error part-way through may leave some steps un-signed.
 func SignSteps(s pipeline.Steps, key jwk.Key, repoURL string, opts ...Option) error {
-	options := options{env: make(map[string]string)}
-	for _, o := range opts {
-		o.apply(&options)
-	}
-
 	for _, step := range s {
 		switch step := step.(type) {
 		case *pipeline.CommandStep:

--- a/signature/steps.go
+++ b/signature/steps.go
@@ -50,8 +50,9 @@ func SignSteps(s pipeline.Steps, key jwk.Key, repoURL string, opts ...Option) er
 }
 
 // SignPipeline adds signatures to each command step (and recursively to any command steps that are within group steps) within a pipeline
-func SignPipeline(p *pipeline.Pipeline, key jwk.Key, repo string, logger Logger, debugSigning bool) error {
-	if err := SignSteps(p.Steps, key, repo, WithEnv(p.Env.ToMap()), WithLogger(logger), WithDebugSigning(debugSigning)); err != nil {
+// func SignPipeline(p *pipeline.Pipeline, key jwk.Key, repo string, logger Logger, debugSigning bool) error {
+func SignPipeline(s pipeline.Steps, key jwk.Key, repo string, opts ...Option) error {
+	if err := SignSteps(s, key, repo, opts...); err != nil {
 		return fmt.Errorf("signing steps: %w", err)
 	}
 	return nil

--- a/signature/steps.go
+++ b/signature/steps.go
@@ -12,7 +12,7 @@ var errSigningRefusedUnknownStepType = errors.New("refusing to sign pipeline con
 
 // SignSteps adds signatures to each command step (and recursively to any command steps that are within group steps).
 // The steps are mutated directly, so an error part-way through may leave some steps un-signed.
-func SignSteps(s pipeline.Steps, key jwk.Key, env map[string]string, repoURL string) error {
+func SignSteps(s pipeline.Steps, key jwk.Key, env map[string]string, repoURL string, logger Logger) error {
 	for _, step := range s {
 		switch step := step.(type) {
 		case *pipeline.CommandStep:
@@ -21,14 +21,14 @@ func SignSteps(s pipeline.Steps, key jwk.Key, env map[string]string, repoURL str
 				RepositoryURL: repoURL,
 			}
 
-			sig, err := Sign(key, env, stepWithInvariants)
+			sig, err := Sign(key, env, stepWithInvariants, logger)
 			if err != nil {
 				return fmt.Errorf("signing step with command %q: %w", step.Command, err)
 			}
 			step.Signature = sig
 
 		case *pipeline.GroupStep:
-			if err := SignSteps(step.Steps, key, env, repoURL); err != nil {
+			if err := SignSteps(step.Steps, key, env, repoURL, logger); err != nil {
 				return fmt.Errorf("signing group step: %w", err)
 			}
 
@@ -45,8 +45,8 @@ func SignSteps(s pipeline.Steps, key jwk.Key, env map[string]string, repoURL str
 }
 
 // SignPipeline adds signatures to each command step (and recursively to any command steps that are within group steps) within a pipeline
-func SignPipeline(p *pipeline.Pipeline, key jwk.Key, repo string) error {
-	if err := SignSteps(p.Steps, key, p.Env.ToMap(), repo); err != nil {
+func SignPipeline(p *pipeline.Pipeline, key jwk.Key, repo string, logger Logger) error {
+	if err := SignSteps(p.Steps, key, p.Env.ToMap(), repo, logger); err != nil {
 		return fmt.Errorf("signing steps: %w", err)
 	}
 	return nil

--- a/signature/steps.go
+++ b/signature/steps.go
@@ -45,7 +45,6 @@ func SignSteps(s pipeline.Steps, key jwk.Key, repoURL string, opts ...Option) er
 }
 
 // SignPipeline adds signatures to each command step (and recursively to any command steps that are within group steps) within a pipeline
-// func SignPipeline(p *pipeline.Pipeline, key jwk.Key, repo string, logger Logger, debugSigning bool) error {
 func SignPipeline(s pipeline.Steps, key jwk.Key, repo string, opts ...Option) error {
 	if err := SignSteps(s, key, repo, opts...); err != nil {
 		return fmt.Errorf("signing steps: %w", err)

--- a/signature/steps.go
+++ b/signature/steps.go
@@ -50,8 +50,8 @@ func SignSteps(s pipeline.Steps, key jwk.Key, repoURL string, opts ...Option) er
 }
 
 // SignPipeline adds signatures to each command step (and recursively to any command steps that are within group steps) within a pipeline
-func SignPipeline(p *pipeline.Pipeline, key jwk.Key, repo string, logger Logger) error {
-	if err := SignSteps(p.Steps, key, repo, WithEnv(p.Env.ToMap()), WithLogger(logger)); err != nil {
+func SignPipeline(p *pipeline.Pipeline, key jwk.Key, repo string, logger Logger, debugSigning bool) error {
+	if err := SignSteps(p.Steps, key, repo, WithEnv(p.Env.ToMap()), WithLogger(logger), WithDebugSigning(debugSigning)); err != nil {
 		return fmt.Errorf("signing steps: %w", err)
 	}
 	return nil


### PR DESCRIPTION
If the key id matches, but the public key isn't derived from the same private key that signed a step, then it's pretty hard to figure out why the signature verification fails.

We don't currently include the public key as part of the signature, just the key-id, so it's hard to validate they are the same.

This allows us to emit them to logs for easier comparison.

### Also
To debug further when faced with unexplained verification failure there is a new debug mode `debug-signing` which will log the step payload being signed/verified so we can verify what is being verified.