### PR TITLE
Canonicalise empty env/plugins/matrix to nil for sign/verify

### DIFF
--- a/signature/pipeline_invariants.go
+++ b/signature/pipeline_invariants.go
@@ -19,9 +19,9 @@ type CommandStepWithInvariants struct {
 func (c *CommandStepWithInvariants) SignedFields() (map[string]any, error) {
 	return map[string]any{
 		"command":        c.Command,
-		"env":            c.Env,
-		"plugins":        c.Plugins,
-		"matrix":         c.Matrix,
+		"env":            EmptyToNilMap(c.Env),
+		"plugins":        EmptyToNilSlice(c.Plugins),
+		"matrix":         EmptyToNilPtr(c.Matrix),
 		"repository_url": c.RepositoryURL,
 	}, nil
 }
@@ -47,13 +47,13 @@ func (c *CommandStepWithInvariants) ValuesForFields(fields []string) (map[string
 			out["command"] = c.Command
 
 		case "env":
-			out["env"] = c.Env
+			out["env"] = EmptyToNilMap(c.Env)
 
 		case "plugins":
-			out["plugins"] = c.Plugins
+			out["plugins"] = EmptyToNilSlice(c.Plugins)
 
 		case "matrix":
-			out["matrix"] = c.Matrix
+			out["matrix"] = EmptyToNilPtr(c.Matrix)
 
 		case "repository_url":
 			out["repository_url"] = c.RepositoryURL

--- a/step_command_matrix.go
+++ b/step_command_matrix.go
@@ -50,6 +50,12 @@ type Matrix struct {
 	RemainingFields map[string]any `yaml:",inline"`
 }
 
+// IsEmpty reports whether the matrix is empty (is nil, or has no setup,
+// no adjustments, and no other data within it).
+func (m *Matrix) IsEmpty() bool {
+	return m == nil || (len(m.Setup) == 0 && len(m.Adjustments) == 0 && len(m.RemainingFields) == 0)
+}
+
 // UnmarshalOrdererd unmarshals from either []any or *ordered.MapSA.
 func (m *Matrix) UnmarshalOrdered(o any) error {
 	switch src := o.(type) {


### PR DESCRIPTION
`jcs` does not canonicalise `{}` and `[]` to `null` (or vice-versa).

`encoding/json` would obey `omitempty` as a directive in a struct field tag, but the `canonicalPayload` isn't encoding `Values` as a struct - it's encoding a `map[string]any`. 

Since there are a bunch of signatures floating about now, I made an educated guess that `null` would be the most common value for un-set `env`, `plugins`, and `matrix`. But this may still break some signatures.