### PR TITLE
Add a checksum of to the payload debugging to detect binary differences

### DIFF
--- a/signature/sign.go
+++ b/signature/sign.go
@@ -3,6 +3,7 @@ package signature
 import (
 	"context"
 	"crypto"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -125,7 +126,7 @@ func Sign(_ context.Context, key jwk.Key, sf SignedFielder, opts ...Option) (*pi
 	}
 
 	if options.debugSigning {
-		debug(options.logger, "Signed Step: %s", payload)
+		debug(options.logger, "Signed Step: %s checksum: %x", payload, sha256.Sum256(payload))
 	}
 
 	sig, err := jws.Sign(nil,
@@ -197,7 +198,7 @@ func Verify(ctx context.Context, s *pipeline.Signature, keySet jwk.Set, sf Signe
 	}
 
 	if options.debugSigning {
-		debug(options.logger, "Signed Step: %s", payload)
+		debug(options.logger, "Signed Step: %s checksum: %x", payload, sha256.Sum256(payload))
 	}
 
 	_, err = jws.Verify([]byte(s.Value),


### PR DESCRIPTION
This change will ensure any subtle differences are picked up in payloads when trouble shooting singing.

This is shown in the signing debug output as follows:

```
2024-08-28 11:28:15 DEBUG  Signed Step: {"alg":"EdDSA","values":{"command":"buildkite/run monolith-tests post-process-test-results","env":{"GIT_CLONE_TYPE":"6months","GIT_LFS_SKIP_SMUDGE":"1"},"env::ARTIFACT_VERSION":"0bd11add9314162b3c1ed03812f84708a611a79b","env::BUILDKITE_COMMIT_TIMESTAMP":"1722296758","env::CI_OUTPUT":"ci-output","env::SKIP_COVERAGE":"true","matrix":null,"plugins":null,"repository_url":"git@github.com:wolfeidau/build-golang-sample.git"}} checksum: ee05a76b25bd9c211af23396d85676003bbafdea96019522fd104e3d0fa7b131 command=tool sign agent_version=3.78.0+x..dirty
```