### PR TITLE
Unmarshal empty lists, allow for adjustment-only build matrix

### DIFF
--- a/ordered/unmarshal.go
+++ b/ordered/unmarshal.go
@@ -16,6 +16,7 @@ import (
 var (
 	ErrIntoNonPointer       = errors.New("cannot unmarshal into non-pointer")
 	ErrIntoNil              = errors.New("cannot unmarshal into nil")
+	ErrNotSettable          = errors.New("target value not settable")
 	ErrIncompatibleTypes    = errors.New("incompatible types")
 	ErrUnsupportedSrc       = errors.New("cannot unmarshal from src")
 	ErrMultipleInlineFields = errors.New(`multiple fields tagged with yaml:",inline"`)
@@ -163,10 +164,16 @@ func Unmarshal(src, dst any) error {
 			if sdst.Kind() != reflect.Slice {
 				return fmt.Errorf("%w: cannot unmarshal []any into %T", ErrIncompatibleTypes, dst)
 			}
-			etype := sdst.Type().Elem() // E = Type of the slice's elements
+			stype := sdst.Type()  // stype = []E = the type of the slice
+			etype := stype.Elem() // etype = E = Type of the slice's elements
+			if sdst.IsNil() {
+				// src isn't nil, so the output slice shouldn't be either.
+				// Use MakeSlice to preallocate the exact size required.
+				sdst = reflect.MakeSlice(stype, 0, len(tsrc))
+			}
 			var warns []error
 			for i, a := range tsrc {
-				x := reflect.New(etype) // *E
+				x := reflect.New(etype) // x := new(E) (type *E)
 				err := Unmarshal(a, x.Interface())
 				if w := warning.As(err); w != nil {
 					warns = append(warns, w.Wrapf("while unmarshaling item at index %d of %d", i, len(tsrc)))
@@ -236,42 +243,63 @@ func (m *Map[K, V]) decodeInto(target any) error {
 	if !ok {
 		return fmt.Errorf("%w: cannot unmarshal from %T, want K=string, V=any", ErrIncompatibleTypes, m)
 	}
+	// Note: m, and therefore tm, can be nil at this moment.
 
 	// Work out the kind of target being used.
 	// Dereference the target to find the inner value, if needed.
 	targetValue := reflect.ValueOf(target)
-	var innerValue reflect.Value
 	switch targetValue.Kind() {
 	case reflect.Pointer:
 		// Passed a pointer to something.
+		if tm == nil {
+			if targetValue.IsNil() {
+				return nil // nothing to do
+			}
+			if !targetValue.CanSet() {
+				return ErrNotSettable
+			}
+			targetValue.SetZero() // which is nil
+			return nil
+		}
 		if targetValue.IsNil() {
 			return ErrIntoNil
 		}
-		innerValue = targetValue.Elem()
+		targetValue = targetValue.Elem()
 
 	case reflect.Map:
-		// Passed a map directly.
-		innerValue = targetValue
-		if innerValue.IsNil() {
-			return ErrIntoNil
-		}
+		// Continue below.
 
 	default:
 		return fmt.Errorf("%w: cannot unmarshal %T into %T, want map or *struct{...}", ErrIncompatibleTypes, m, target)
 	}
 
-	switch innerValue.Kind() {
+	switch targetValue.Kind() {
 	case reflect.Map:
 		// Process the map directly.
-		mapType := innerValue.Type()
+		mapType := targetValue.Type()
 		// For simplicity, require the key type to be string.
 		if keyType := mapType.Key(); keyType.Kind() != reflect.String {
 			return fmt.Errorf("%w for map key: cannot unmarshal %T into %T", ErrIncompatibleTypes, m, target)
 		}
 
-		// If target is a pointer to a nil map (with type), create a new map.
-		if innerValue.IsNil() {
-			innerValue.Set(reflect.MakeMapWithSize(mapType, tm.Len()))
+		// If tm is nil, then set the target to nil.
+		if tm == nil {
+			if targetValue.IsNil() {
+				// Nothing to do.
+				return nil
+			}
+			if !targetValue.CanSet() {
+				return ErrNotSettable
+			}
+			targetValue.SetZero() // which is nil
+			return nil
+		}
+		// Otherwise, if target is a pointer to a nil map (with type), create a new map.
+		if targetValue.IsNil() {
+			if !targetValue.CanSet() {
+				return ErrNotSettable
+			}
+			targetValue.Set(reflect.MakeMapWithSize(mapType, tm.Len()))
 		}
 
 		valueType := mapType.Elem()
@@ -285,7 +313,7 @@ func (m *Map[K, V]) decodeInto(target any) error {
 				return fmt.Errorf("unmarshaling value for key %q: %w", k, err)
 			}
 
-			innerValue.SetMapIndex(reflect.ValueOf(k), nv.Elem())
+			targetValue.SetMapIndex(reflect.ValueOf(k), nv.Elem())
 			return nil
 		}); err != nil {
 			return err
@@ -300,7 +328,7 @@ func (m *Map[K, V]) decodeInto(target any) error {
 
 	// These are the (accessible by reflection) fields it has.
 	// This includes non-exported fields.
-	fields := reflect.VisibleFields(innerValue.Type())
+	fields := reflect.VisibleFields(targetValue.Type())
 
 	var inlineField reflect.StructField
 	outlineKeys := make(map[string]struct{})
@@ -362,7 +390,7 @@ func (m *Map[K, V]) decodeInto(target any) error {
 
 		// Now load value into the field recursively.
 		// Get a pointer to the field. This works because target is a pointer.
-		ptrToField := innerValue.FieldByIndex(field.Index).Addr()
+		ptrToField := targetValue.FieldByIndex(field.Index).Addr()
 		err := Unmarshal(value, ptrToField.Interface())
 		if w := warning.As(err); w != nil {
 			warns = append(warns, w.Wrapf("while unmarshaling the value for key %q into struct field %q", key, field.Name))
@@ -377,7 +405,7 @@ func (m *Map[K, V]) decodeInto(target any) error {
 	// The rest is handling the ",inline" field.
 	// We support any field that Unmarshal can unmarshal tm into.
 
-	inlinePtr := innerValue.FieldByIndex(inlineField.Index).Addr()
+	inlinePtr := targetValue.FieldByIndex(inlineField.Index).Addr()
 
 	// Copy all values that weren't non-inline fields into a temporary map.
 	// This is just to avoid mutating tm.

--- a/ordered/unmarshal_test.go
+++ b/ordered/unmarshal_test.go
@@ -700,14 +700,9 @@ func TestUnmarshalIntoNilErrors(t *testing.T) {
 			dst:  (*MapSA)(nil),
 		},
 		{
-			desc: "*MapSA into *map[string]any nil",
+			desc: "non-nil *MapSA into nil *map[string]any",
 			src:  MapFromItems(TupleSA{}),
 			dst:  (*map[string]any)(nil),
-		},
-		{
-			desc: "*MapSA into map[string]any nil",
-			src:  MapFromItems(TupleSA{}),
-			dst:  (map[string]any)(nil),
 		},
 		{
 			desc: "*MapSA into *any nil",
@@ -782,6 +777,35 @@ func TestUnmarshalIntoNilErrors(t *testing.T) {
 
 			if err := Unmarshal(test.src, test.dst); !errors.Is(err, ErrIntoNil) {
 				t.Errorf("Unmarshal(%T, %T) error = %v, want %v", test.src, test.dst, err, ErrIntoNil)
+			}
+		})
+	}
+}
+
+func TestUnmarshalNotSettableErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		desc     string
+		src, dst any
+	}{
+		{
+			desc: "*MapSA into map[string]any nil",
+			src:  MapFromItems(TupleSA{}),
+			dst:  (map[string]any)(nil),
+		},
+		{
+			desc: "*MapSA(nil) to *map[string]any",
+			src:  (*MapSA)(nil),
+			dst:  new(map[string]any), // NB: not make
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			if err := Unmarshal(test.src, test.dst); !errors.Is(err, ErrNotSettable) {
+				t.Errorf("Unmarshal(%T, %T) error = %v, want %v", test.src, test.dst, err, ErrNotSettable)
 			}
 		})
 	}

--- a/parser_matrix_test.go
+++ b/parser_matrix_test.go
@@ -454,7 +454,11 @@ steps:
   "steps": [
     {
       "command": "echo {{matrix}}",
-      "matrix": []
+      "matrix": {
+        "setup": {
+          "arch": []
+        }
+      }
     }
   ]
 }`,

--- a/parser_matrix_test.go
+++ b/parser_matrix_test.go
@@ -429,6 +429,36 @@ steps:
   ]
 }`,
 		},
+		{
+			desc: "Empty setup list",
+			input: `---
+steps:
+  - command: echo {{matrix}}
+    matrix:
+      setup:
+        arch: []
+`,
+			want: &Pipeline{
+				Steps: Steps{
+					&CommandStep{
+						Command: "echo {{matrix}}",
+						Matrix: &Matrix{
+							Setup: MatrixSetup{
+								"arch": {},
+							},
+						},
+					},
+				},
+			},
+			wantJSON: `{
+  "steps": [
+    {
+      "command": "echo {{matrix}}",
+      "matrix": []
+    }
+  ]
+}`,
+		},
 	}
 
 	for _, test := range tests {

--- a/parser_test.go
+++ b/parser_test.go
@@ -1414,7 +1414,7 @@ steps:
 			&CommandStep{
 				Command: "x",
 				Matrix: &Matrix{
-					Setup: MatrixSetup{},
+					Setup: MatrixSetup{"a": {}},
 					Adjustments: MatrixAdjustments{
 						&MatrixAdjustment{With: MatrixAdjustmentWith{"a": "apple"}},
 					},

--- a/step_command_matrix.go
+++ b/step_command_matrix.go
@@ -147,7 +147,9 @@ func (m *Matrix) validatePermutation(p MatrixPermutation) error {
 	// Check that the dimensions in the permutation are unique and defined in
 	// the matrix setup.
 	for dim := range p {
-		if len(m.Setup[dim]) == 0 {
+		// An empty but non-nil setup dimension is valid (all values may be
+		// given by adjustment tuples).
+		if m.Setup[dim] == nil {
 			return fmt.Errorf("%w: %q", errPermutationUnknownDimension, dim)
 		}
 	}
@@ -180,7 +182,9 @@ func (m *Matrix) validatePermutation(p MatrixPermutation) error {
 			return fmt.Errorf("%w: %d != %d", errAdjustmentLengthMismatch, len(adj.With), len(m.Setup))
 		}
 		for dim := range adj.With {
-			if len(m.Setup[dim]) == 0 {
+			// An empty but non-nil setup dimension is valid (all values may be
+			// given by adjustment tuples).
+			if m.Setup[dim] == nil {
 				return fmt.Errorf("%w: %q", errAdjustmentUnknownDimension, dim)
 			}
 		}

--- a/step_command_matrix_test.go
+++ b/step_command_matrix_test.go
@@ -91,6 +91,51 @@ func TestMatrix_ValidatePermutation_Simple(t *testing.T) {
 	}
 }
 
+func TestMatrix_ValidatePermutation_AdjustmentOnly(t *testing.T) {
+	t.Parallel()
+
+	matrix := &Matrix{
+		Setup: MatrixSetup{
+			"arch": {},
+		},
+		Adjustments: MatrixAdjustments{
+			{
+				With: MatrixAdjustmentWith{
+					"arch": "aarch64",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		perm MatrixPermutation
+		want error
+	}{
+		{
+			name: "basic match",
+			perm: MatrixPermutation{"arch": "aarch64"},
+			want: nil,
+		},
+		{
+			name: "basic mismatch",
+			perm: MatrixPermutation{"arch": "Arc de Triomphe"},
+			want: errPermutationNoMatch,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := matrix.validatePermutation(test.perm)
+			if !errors.Is(err, test.want) {
+				t.Errorf("matrix.validatePermutation(%v) = %v, want %v", test.perm, err, test.want)
+			}
+		})
+	}
+}
+
 func TestMatrix_ValidatePermutation_Multiple(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Perhaps it should be possible to define empty dimension lists, and then specify values for those dimensions via adjustments.

This pull request is currently ~just a failing test~ ~just some failing tests~ some tests by @pda and a solution written by @DrJosh9000 🙏🏼

Currently, an empty list gets converted to `null` which gets rejected server-side as being an invalid value for a matrix dimension value.

e.g. currently a pipeline like this:

```yaml
steps:

  - command: "echo {{matrix.color}} {{matrix.shape}}"
    label: "{{matrix.color}} {{matrix.shape}}"
    matrix:
      setup:
        color: []
        shape: []
      adjustments:
        - with: { color: "green", shape: "hexagon" }
        - with: { color: "blue", shape: "triangle" }
```

is rejected with this error:

> fatal: Failed to upload and process pipeline: Pipeline upload rejected: Each item within a matrix must be either a string, boolean or integer

Because the `setup` is uploaded as `"setup":{"color":null,"shape":null}`.