### PR TITLE
Add VerifyStep, un-export CommandStepWithInvariants

### DIFF
--- a/signature/pipeline_invariants.go
+++ b/signature/pipeline_invariants.go
@@ -7,27 +7,53 @@ import (
 	"github.com/buildkite/go-pipeline"
 )
 
-var _ SignedFielder = (*CommandStepWithInvariants)(nil)
+// EnvNamespacePrefix is the string that prefixes all fields in the "env"
+// namespace. This is used to separate signed data that came from the
+// environment from data that came from an object.
+const EnvNamespacePrefix = "env::"
 
-// CommandStepWithInvariants is a CommandStep with PipelineInvariants.
-type CommandStepWithInvariants struct {
+var _ SignedFielder = (*commandStepWithInvariants)(nil)
+
+// commandStepWithInvariants is a CommandStep with pipeline invariants.
+// Pipeline invariants are things like the repository URL (since mutating that
+// could cause the agent to download the wrong code to build) and pipeline-
+// -level env vars (since they can greatly affect how a job is run and provide
+// ample means of side-stepping protections e.g. shell injections).
+type commandStepWithInvariants struct {
 	pipeline.CommandStep
 	RepositoryURL string
+	// For signing, OuterEnv is the pipeline env.
+	// For verifying, OuterEnv is the job env.
+	OuterEnv map[string]string
 }
 
 // SignedFields returns the default fields for signing.
-func (c *CommandStepWithInvariants) SignedFields() (map[string]any, error) {
-	return map[string]any{
+func (c *commandStepWithInvariants) SignedFields() (map[string]any, error) {
+	object := map[string]any{
 		"command":        c.Command,
 		"env":            EmptyToNilMap(c.Env),
 		"plugins":        EmptyToNilSlice(c.Plugins),
 		"matrix":         EmptyToNilPtr(c.Matrix),
 		"repository_url": c.RepositoryURL,
-	}, nil
+	}
+
+	// Step env overrides pipeline and build env:
+	// https://buildkite.com/docs/tutorials/pipeline-upgrade#what-is-the-yaml-steps-editor-compatibility-issues
+	// (Beware of inconsistent docs written in the time of legacy steps.)
+	// So step env vars exclude pipeline vars from signing.
+	// Namespace the env values and include them in the values to sign.
+	for k, v := range c.OuterEnv {
+		if _, has := c.Env[k]; has {
+			continue
+		}
+		object[EnvNamespacePrefix+k] = v
+	}
+
+	return object, nil
 }
 
 // ValuesForFields returns the contents of fields to sign.
-func (c *CommandStepWithInvariants) ValuesForFields(fields []string) (map[string]any, error) {
+func (c *commandStepWithInvariants) ValuesForFields(fields []string) (map[string]any, error) {
 	// Make a set of required fields. As fields is processed, mark them off by
 	// deleting them.
 	required := map[string]struct{}{
@@ -59,8 +85,13 @@ func (c *CommandStepWithInvariants) ValuesForFields(fields []string) (map[string
 			out["repository_url"] = c.RepositoryURL
 
 		default:
-			// All env:: values come from outside the step.
-			if strings.HasPrefix(f, EnvNamespacePrefix) {
+			if name, has := strings.CutPrefix(f, EnvNamespacePrefix); has {
+				// Do we have that env var?
+				if value, has := c.OuterEnv[name]; has {
+					out[f] = value
+				} else {
+					return nil, fmt.Errorf("variable %q missing from environment", name)
+				}
 				break
 			}
 

--- a/signature/sign.go
+++ b/signature/sign.go
@@ -17,11 +17,6 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jws"
 )
 
-// EnvNamespacePrefix is the string that prefixes all fields in the "env"
-// namespace. This is used to separate signed data that came from the
-// environment from data that came from an object.
-const EnvNamespacePrefix = "env::"
-
 // SignedFielder describes types that can be signed and have signatures
 // verified.
 // Converting non-string fields into strings (in a stable, canonical way) is an
@@ -43,31 +38,51 @@ type SignedFielder interface {
 type Logger interface{ Debug(f string, v ...any) }
 
 type options struct {
-	env          map[string]string
+	env          map[string]string // not used in Sign or Verify
 	logger       Logger
 	debugSigning bool
 }
 
+// Allow *options to pass through SignOrVerifyOption.
+func (o *options) apply(opts *options) { *opts = *o }
+func (*options) signOrVerifyTag()      {}
+
+// Option implementations provide extra parameters. This type encompasses all
+// options, whether or not they are allowed to be passed to Sign or Verify.
 type Option interface {
 	apply(*options)
 }
 
-type envOption struct{ env map[string]string }
+// SignOrVerifyOption are the subtype of options that can be passed to Sign
+// or to Verify.
+type SignOrVerifyOption interface {
+	Option
+
+	// This tag ensures that options that aren't one of the specifically-tagged
+	// options cannot be passed to Sign or Verify.
+	signOrVerifyTag()
+}
+
 type loggerOption struct{ logger Logger }
+
+func (o loggerOption) apply(opts *options) { opts.logger = o.logger }
+func (loggerOption) signOrVerifyTag()      {}
+
 type debugSigningOption struct{ debugSigning bool }
 
-func (o envOption) apply(opts *options)          { opts.env = o.env }
-func (o loggerOption) apply(opts *options)       { opts.logger = o.logger }
 func (o debugSigningOption) apply(opts *options) { opts.debugSigning = o.debugSigning }
+func (debugSigningOption) signOrVerifyTag()      {}
 
-func WithEnv(env map[string]string) Option      { return envOption{env} }
-func WithLogger(logger Logger) Option           { return loggerOption{logger} }
-func WithDebugSigning(debugSigning bool) Option { return debugSigningOption{debugSigning} }
+// WithLogger provides a logger to use for debug logging.
+func WithLogger(logger Logger) SignOrVerifyOption { return loggerOption{logger} }
 
-func configureOptions(opts ...Option) options {
-	options := options{
-		env: make(map[string]string),
-	}
+// WithDebugSigning enables or disables signing debugging. Aside from logging
+// verbosely, enabling this may risk disclosing information that could break the
+// encryption properties of the signature.
+func WithDebugSigning(debugSigning bool) SignOrVerifyOption { return debugSigningOption{debugSigning} }
+
+func configureOptions[E Option](opts []E) options {
+	options := options{}
 	for _, o := range opts {
 		o.apply(&options)
 	}
@@ -78,11 +93,11 @@ type Key interface {
 	Algorithm() jwa.KeyAlgorithm
 }
 
-// Sign computes a new signature for an environment (env) combined with an
-// object containing values (sf) using a given key. The key can be a jwk.Key
-// or a crypto.Signer. If it is a jwk.Key, the public key thumbprint is logged.
-func Sign(_ context.Context, key Key, sf SignedFielder, opts ...Option) (*pipeline.Signature, error) {
-	options := configureOptions(opts...)
+// Sign computes a new signature for object containing values (sf) using a given
+// key. The key can be a jwk.Key or a crypto.Signer. If it is a jwk.Key, the
+// public key thumbprint is logged.
+func Sign(_ context.Context, key Key, sf SignedFielder, opts ...SignOrVerifyOption) (*pipeline.Signature, error) {
+	options := configureOptions(opts)
 
 	values, err := sf.SignedFields()
 	if err != nil {
@@ -90,21 +105,6 @@ func Sign(_ context.Context, key Key, sf SignedFielder, opts ...Option) (*pipeli
 	}
 	if len(values) == 0 {
 		return nil, errors.New("no fields to sign")
-	}
-
-	// Step env overrides pipeline and build env:
-	// https://buildkite.com/docs/tutorials/pipeline-upgrade#what-is-the-yaml-steps-editor-compatibility-issues
-	// (Beware of inconsistent docs written in the time of legacy steps.)
-	// So if the thing we're signing has an env map, use it to exclude pipeline
-	// vars from signing.
-	objEnv, _ := values["env"].(map[string]string)
-
-	// Namespace the env values and include them in the values to sign.
-	for k, v := range options.env {
-		if _, has := objEnv[k]; has {
-			continue
-		}
-		values[EnvNamespacePrefix+k] = v
 	}
 
 	// Extract the names of the fields.
@@ -166,8 +166,8 @@ func Sign(_ context.Context, key Key, sf SignedFielder, opts ...Option) (*pipeli
 // Verify verifies an existing signature against environment (env) combined with
 // the keyset. The keySet can be a jwk.Set or a crypto.Signer. If it is a jwk.Set,
 // the public key thumbprints are logged.
-func Verify(ctx context.Context, s *pipeline.Signature, keySet any, sf SignedFielder, opts ...Option) error {
-	options := configureOptions(opts...)
+func Verify(ctx context.Context, s *pipeline.Signature, keySet any, sf SignedFielder, opts ...SignOrVerifyOption) error {
+	options := configureOptions(opts)
 
 	if len(s.SignedFields) == 0 {
 		return errors.New("signature covers no fields")
@@ -179,23 +179,6 @@ func Verify(ctx context.Context, s *pipeline.Signature, keySet any, sf SignedFie
 		return fmt.Errorf("obtaining values for fields: %w", err)
 	}
 
-	// See Sign above for why we need special handling for step env.
-	objEnv, _ := values["env"].(map[string]string)
-
-	// Namespace the env values and include them in the values to sign.
-	for k, v := range options.env {
-		if _, has := objEnv[k]; has {
-			continue
-		}
-		values[EnvNamespacePrefix+k] = v
-	}
-
-	// env:: fields that were signed are all required from the env map.
-	// We can't verify other env vars though - they can vary for lots of reasons
-	// (e.g. Buildkite-provided vars added by the backend.)
-	// This is still strong enough for a user to enforce any particular env var
-	// exists and has a particular value - make it a part of the pipeline or
-	// step env.
 	required, err := requireKeys(values, s.SignedFields)
 	if err != nil {
 		return fmt.Errorf("obtaining required keys: %w", err)

--- a/signature/sign_test.go
+++ b/signature/sign_test.go
@@ -48,20 +48,26 @@ func TestSignVerify(t *testing.T) {
 			"DEPLOY":  "0",
 		},
 	}
-	// The pipeline-level env that the agent uploads:
-	signEnv := map[string]string{
-		"DEPLOY": "1",
-	}
-	// The backend combines the pipeline and step envs, providing a new env:
-	verifyEnv := map[string]string{
-		"CONTEXT": "cats",
-		"DEPLOY":  "0",
-		"MISC":    "llama drama",
-	}
 
-	stepWithInvariants := &CommandStepWithInvariants{
+	stepToSign := &commandStepWithInvariants{
 		CommandStep:   *step,
 		RepositoryURL: "fake-repo",
+		// The pipeline containing all the steps can define some top-level env
+		// vars that work like defaults for all steps.
+		OuterEnv: map[string]string{
+			"DEPLOY": "1",
+		},
+	}
+	stepToVerify := &commandStepWithInvariants{
+		CommandStep:   *step,
+		RepositoryURL: "fake-repo",
+		// The backend combines the pipeline and step envs and adds several new
+		// env vars of its own, and returns that when serving up the job to run.
+		OuterEnv: map[string]string{
+			"CONTEXT": "cats",
+			"DEPLOY":  "0",
+			"MISC":    "llama drama",
+		},
 	}
 
 	cases := []struct {
@@ -106,9 +112,9 @@ func TestSignVerify(t *testing.T) {
 				t.Fatalf("jwkutil.LoadKey(%v, %v) error = %v", privPath, keyName, err)
 			}
 
-			sig, err := Sign(ctx, sKey, stepWithInvariants, WithEnv(signEnv))
+			sig, err := Sign(ctx, sKey, stepToSign)
 			if err != nil {
-				t.Fatalf("Sign(ctx, sKey, %v, WithEnv(%v)) error = %v", stepWithInvariants, signEnv, err)
+				t.Fatalf("Sign(ctx, sKey, %v) error = %v", stepToSign, err)
 			}
 
 			if sig.Algorithm != tc.alg.String() {
@@ -132,8 +138,8 @@ func TestSignVerify(t *testing.T) {
 				t.Fatalf("verifier.AddKey(%v) error = %v", vKey, err)
 			}
 
-			if err := Verify(ctx, sig, verifier, stepWithInvariants, WithEnv(verifyEnv)); err != nil {
-				t.Errorf("Verify(ctx, %v, verifier, %v, WithEnv(%v)) = %v", sig, stepWithInvariants, verifyEnv, err)
+			if err := Verify(ctx, sig, verifier, stepToVerify); err != nil {
+				t.Errorf("Verify(ctx, %v, verifier, %v) = %v", sig, stepToVerify, err)
 			}
 		})
 	}
@@ -178,21 +184,26 @@ func TestSignVerifyCryptoSigner(t *testing.T) {
 			"DEPLOY":  "0",
 		},
 	}
-	// The pipeline-level env that the agent uploads:
-	signEnv := map[string]string{
-		"DEPLOY": "1",
-	}
 
-	// The backend combines the pipeline and step envs, providing a new env:
-	verifyEnv := map[string]string{
-		"CONTEXT": "cats",
-		"DEPLOY":  "0",
-		"MISC":    "llama drama",
-	}
-
-	stepWithInvariants := &CommandStepWithInvariants{
+	stepToSign := &commandStepWithInvariants{
 		CommandStep:   *step,
 		RepositoryURL: "fake-repo",
+		// The pipeline containing all the steps can define some top-level env
+		// vars that work like defaults for all steps.
+		OuterEnv: map[string]string{
+			"DEPLOY": "1",
+		},
+	}
+	stepToVerify := &commandStepWithInvariants{
+		CommandStep:   *step,
+		RepositoryURL: "fake-repo",
+		// The backend combines the pipeline and step envs and adds several new
+		// env vars of its own, and returns that when serving up the job to run.
+		OuterEnv: map[string]string{
+			"CONTEXT": "cats",
+			"DEPLOY":  "0",
+			"MISC":    "llama drama",
+		},
 	}
 
 	cases := []struct {
@@ -249,17 +260,17 @@ func TestSignVerifyCryptoSigner(t *testing.T) {
 				publickKey: publicKey,
 			}
 
-			sig, err := Sign(ctx, sKey, stepWithInvariants, WithEnv(signEnv))
+			sig, err := Sign(ctx, sKey, stepToSign)
 			if err != nil {
-				t.Fatalf("Sign(ctx, sKey, %v, WithEnv(%v)) error = %v", stepWithInvariants, signEnv, err)
+				t.Fatalf("Sign(ctx, sKey, %v) error = %v", stepToSign, err)
 			}
 
 			if sig.Algorithm != tc.alg.String() {
 				t.Errorf("Signature.Algorithm = %v, want %v", sig.Algorithm, tc.alg)
 			}
 
-			if err := Verify(ctx, sig, sKey, stepWithInvariants, WithEnv(verifyEnv)); err != nil {
-				t.Errorf("Verify(ctx, %v, verifier, %v, WithEnv(%v)) = %v", sig, stepWithInvariants, verifyEnv, err)
+			if err := Verify(ctx, sig, sKey, stepToVerify); err != nil {
+				t.Errorf("Verify(ctx, %v, verifier, %v) = %v", sig, stepToVerify, err)
 			}
 
 		})
@@ -358,7 +369,7 @@ func TestUnknownAlgorithm(t *testing.T) {
 
 	key.Set(jwk.AlgorithmKey, "rot13")
 
-	step := &CommandStepWithInvariants{
+	step := &commandStepWithInvariants{
 		CommandStep: pipeline.CommandStep{
 			Command: "llamas",
 		},
@@ -373,7 +384,7 @@ func TestVerifyBadSignature(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	cs := &CommandStepWithInvariants{CommandStep: pipeline.CommandStep{Command: "llamas"}}
+	cs := &commandStepWithInvariants{CommandStep: pipeline.CommandStep{Command: "llamas"}}
 
 	sig := &pipeline.Signature{
 		Algorithm:    "HS256",
@@ -476,7 +487,6 @@ func TestSignVerifyEnv(t *testing.T) {
 				"DEPLOY":  "1",
 			},
 			verifyEnv: map[string]string{
-				// NB: pipeline env overrides step env.
 				"CONTEXT": "dogs",
 				"DEPLOY":  "1",
 				"MISC":    "apple",
@@ -499,18 +509,24 @@ func TestSignVerifyEnv(t *testing.T) {
 				t.Fatalf("signer.Key(0) = _, false, want true")
 			}
 
-			stepWithInvariants := &CommandStepWithInvariants{
+			stepToSign := &commandStepWithInvariants{
 				CommandStep:   *tc.step,
 				RepositoryURL: tc.repositoryURL,
+				OuterEnv:      tc.pipelineEnv,
+			}
+			stepToVerify := &commandStepWithInvariants{
+				CommandStep:   *tc.step,
+				RepositoryURL: tc.repositoryURL,
+				OuterEnv:      tc.verifyEnv,
 			}
 
-			sig, err := Sign(ctx, key, stepWithInvariants, WithEnv(tc.pipelineEnv))
+			sig, err := Sign(ctx, key, stepToSign)
 			if err != nil {
-				t.Fatalf("Sign(ctx, key, %v, WithEnv(%v)) error = %v", stepWithInvariants, tc.pipelineEnv, err)
+				t.Fatalf("Sign(ctx, key, %v) error = %v", stepToSign, err)
 			}
 
-			if err := Verify(ctx, sig, verifier, stepWithInvariants, WithEnv(tc.verifyEnv)); err != nil {
-				t.Errorf("Verify(ctx, %v, verifier, %v, WithEnv(%v)) = %v", sig, stepWithInvariants, tc.verifyEnv, err)
+			if err := Verify(ctx, sig, verifier, stepToVerify); err != nil {
+				t.Errorf("Verify(ctx, %v, verifier, %v) = %v", sig, stepToVerify, err)
 			}
 		})
 	}
@@ -619,11 +635,11 @@ func TestSignVerify_NilVsEmpty(t *testing.T) {
 				t.Fatalf("signer.Key(0) = _, false, want true")
 			}
 
-			toSign := &CommandStepWithInvariants{
+			toSign := &commandStepWithInvariants{
 				CommandStep:   *tc.stepSign,
 				RepositoryURL: fakeRepositoryURL,
 			}
-			toVerify := &CommandStepWithInvariants{
+			toVerify := &commandStepWithInvariants{
 				CommandStep:   *tc.stepVerify,
 				RepositoryURL: fakeRepositoryURL,
 			}
@@ -659,10 +675,7 @@ func TestSignatureStability(t *testing.T) {
 			Config: pluginCfg,
 		}},
 	}
-	stepWithInvariants := &CommandStepWithInvariants{
-		CommandStep:   *step,
-		RepositoryURL: fakeRepositoryURL,
-	}
+
 	env := make(map[string]string)
 
 	// there are n! permutations of n items, but only one is correct
@@ -685,13 +698,19 @@ func TestSignatureStability(t *testing.T) {
 		t.Fatalf("signer.Key(0) = _, false, want true")
 	}
 
-	sig, err := Sign(ctx, key, stepWithInvariants, WithEnv(env))
-	if err != nil {
-		t.Fatalf("Sign(ctx, key, %v, WithEnv(%v)) error = %v", stepWithInvariants, env, err)
+	stepWithInvariants := &commandStepWithInvariants{
+		CommandStep:   *step,
+		RepositoryURL: fakeRepositoryURL,
+		OuterEnv:      env,
 	}
 
-	if err := Verify(ctx, sig, verifier, stepWithInvariants, WithEnv(env)); err != nil {
-		t.Errorf("Verify(ctx, %v, verifier, %v, WithEnv(%v)) = %v", sig, stepWithInvariants, env, err)
+	sig, err := Sign(ctx, key, stepWithInvariants)
+	if err != nil {
+		t.Fatalf("Sign(ctx, key, %v) error = %v", stepWithInvariants, err)
+	}
+
+	if err := Verify(ctx, sig, verifier, stepWithInvariants); err != nil {
+		t.Errorf("Verify(ctx, %v, verifier, %v) = %v", sig, stepWithInvariants, err)
 	}
 }
 
@@ -721,9 +740,10 @@ func TestDebugSigning(t *testing.T) {
 		"DEPLOY": "1",
 	}
 
-	stepWithInvariants := &CommandStepWithInvariants{
+	stepWithInvariants := &commandStepWithInvariants{
 		CommandStep:   *step,
 		RepositoryURL: "fake-repo",
+		OuterEnv:      signEnv,
 	}
 
 	wd, err := os.Getwd()
@@ -745,7 +765,7 @@ func TestDebugSigning(t *testing.T) {
 
 	// Test that step payload is not logged when debugSigning is false
 	logger := &fakeLogger{}
-	_, err = Sign(ctx, sKey, stepWithInvariants, WithEnv(signEnv), WithDebugSigning(false), WithLogger(logger))
+	_, err = Sign(ctx, sKey, stepWithInvariants, WithDebugSigning(false), WithLogger(logger))
 	if err != nil {
 		t.Fatalf("Sign(ctx, sKey, %v, WithEnv(%v), WithDebugSigning(false), WithLogger(logger)) error = %v", stepWithInvariants, signEnv, err)
 	}
@@ -760,7 +780,7 @@ func TestDebugSigning(t *testing.T) {
 
 	// Test that step payload is logged when debugSigning is true
 	logger = &fakeLogger{}
-	_, err = Sign(ctx, sKey, stepWithInvariants, WithEnv(signEnv), WithDebugSigning(true), WithLogger(logger))
+	_, err = Sign(ctx, sKey, stepWithInvariants, WithDebugSigning(true), WithLogger(logger))
 	if err != nil {
 		t.Fatalf("Sign(ctx, sKey, %v, WithEnv(%v), WithDebugSigning(true), WithLogger(logger)) error = %v", stepWithInvariants, signEnv, err)
 	}

--- a/signature/steps.go
+++ b/signature/steps.go
@@ -8,27 +8,43 @@ import (
 	"github.com/buildkite/go-pipeline"
 )
 
+// errSigningRefusedUnknownStepType is returned by SignSteps when any of the
+// steps is UnknownStep.
 var errSigningRefusedUnknownStepType = errors.New("refusing to sign pipeline containing a step of unknown type, because the pipeline could be incorrectly parsed - please contact support")
+
+// ErrNoSignature is returned by VerifyStep when the step has no signature.
+var ErrNoSignature = errors.New("job had no signature to verify")
+
+// WithEnv provides external (pipeline / job) env vars for signing and verifying
+// as part of an object.
+func WithEnv(env map[string]string) Option { return envOption{env} }
+
+type envOption struct{ env map[string]string }
+
+func (o envOption) apply(opts *options) { opts.env = o.env }
 
 // SignSteps adds signatures to each command step (and recursively to any command steps that are within group steps).
 // The steps are mutated directly, so an error part-way through may leave some steps un-signed.
 func SignSteps(ctx context.Context, s pipeline.Steps, key Key, repoURL string, opts ...Option) error {
+	options := configureOptions(opts)
+
 	for _, step := range s {
 		switch step := step.(type) {
 		case *pipeline.CommandStep:
-			stepWithInvariants := &CommandStepWithInvariants{
+			stepWithInvariants := &commandStepWithInvariants{
 				CommandStep:   *step,
 				RepositoryURL: repoURL,
+				OuterEnv:      options.env,
 			}
 
-			sig, err := Sign(ctx, key, stepWithInvariants, opts...)
+			sig, err := Sign(ctx, key, stepWithInvariants, &options)
 			if err != nil {
 				return fmt.Errorf("signing step with command %q: %w", step.Command, err)
 			}
 			step.Signature = sig
 
 		case *pipeline.GroupStep:
-			if err := SignSteps(ctx, step.Steps, key, repoURL, opts...); err != nil {
+			if err := SignSteps(ctx, step.Steps, key, repoURL, &options); err != nil {
 				return fmt.Errorf("signing group step: %w", err)
 			}
 
@@ -42,4 +58,22 @@ func SignSteps(ctx context.Context, s pipeline.Steps, key Key, repoURL string, o
 		}
 	}
 	return nil
+}
+
+// VerifyStep verifies the signature contained within a CommandStep.
+func VerifyStep(ctx context.Context, step *pipeline.CommandStep, keySet any, repoURL string, opts ...Option) error {
+	options := configureOptions(opts)
+
+	if step.Signature == nil {
+		return ErrNoSignature
+	}
+
+	stepWithInvariants := &commandStepWithInvariants{
+		CommandStep:   *step,
+		RepositoryURL: repoURL,
+		OuterEnv:      options.env,
+	}
+
+	// Verify the signature
+	return Verify(ctx, step.Signature, keySet, stepWithInvariants, &options)
 }

--- a/step_command_matrix.go
+++ b/step_command_matrix.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/buildkite/go-pipeline/ordered"
 	"gopkg.in/yaml.v3"
@@ -158,14 +159,7 @@ func (m *Matrix) validatePermutation(p MatrixPermutation) error {
 	// permutation). Whether they are or are not, we still check adjustments.
 	valid := true
 	for dim, val := range p {
-		match := false
-		for _, v := range m.Setup[dim] {
-			if val == v {
-				match = true
-				break
-			}
-		}
-		if !match {
+		if !slices.Contains(m.Setup[dim], val) {
 			// Not a basic permutation. It could still be an adjustment though.
 			valid = false
 			break


### PR DESCRIPTION
### What

API breaking change.

Add a `VerifyStep` function that sets up `commandStepWithInvariants` with the env in a way that replaces the existing behaviour, and un-export `commandStepWithInvariants` to force calling code to update.

### Why
The original vision for `Sign` and `Verify` was to treat the object being signed and verified as abstractly as possible, so that they could focus on canonical encoding and driving the JWKS signing/verifying correctly. 

Unfortunately pipeline/job env was special and leaked through the abstraction layer. `Sign` and `Verify` changed to take an outer env, and then apply namespace-prefixing and the step-env-over-outer-env precedence internally.

A better path was paved with `CommandStepWithInvariants`, in order to sign repo URLs. We can treat the env vars in the same way.