### PR TITLE
Support pipeline `secrets` syntax

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -13,8 +13,9 @@ import (
 //
 // Standard caveats apply - see the package comment.
 type Pipeline struct {
-	Steps Steps          `yaml:"steps"`
-	Env   *ordered.MapSS `yaml:"env,omitempty"`
+	Steps   Steps          `yaml:"steps"`
+	Env     *ordered.MapSS `yaml:"env,omitempty"`
+	Secrets Secrets        `yaml:"secrets,omitempty"`
 
 	// RemainingFields stores any other top-level mapping items so they at least
 	// survive an unmarshal-marshal round-trip.

--- a/pipeline_secrets_test.go
+++ b/pipeline_secrets_test.go
@@ -1,0 +1,124 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/buildkite/go-pipeline/ordered"
+	"gopkg.in/yaml.v3"
+)
+
+func TestPipelineSecretsUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	// Test parsing pipeline with build-level secrets
+	yamlData := `
+secrets:
+  - DATABASE_URL
+  - API_TOKEN
+steps:
+  - command: echo "hello"
+`
+
+	var p Pipeline
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(yamlData), &node)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err = ordered.Unmarshal(&node, &p)
+	if err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	if len(p.Secrets) != 2 {
+		t.Fatalf("len(p.Secrets) = %d, want 2", len(p.Secrets))
+	}
+
+	// Check first secret
+	if p.Secrets[0].Key != "DATABASE_URL" {
+		t.Errorf("p.Secrets[0].Key = %q, want %q", p.Secrets[0].Key, "DATABASE_URL")
+	}
+	if *p.Secrets[0].EnvironmentVariable != "DATABASE_URL" {
+		t.Errorf("p.Secrets[0].EnvironmentVariable = %q, want %q", *p.Secrets[0].EnvironmentVariable, "DATABASE_URL")
+	}
+
+	// Check second secret
+	if p.Secrets[1].Key != "API_TOKEN" {
+		t.Errorf("p.Secrets[1].Key = %q, want %q", p.Secrets[1].Key, "API_TOKEN")
+	}
+	if *p.Secrets[1].EnvironmentVariable != "API_TOKEN" {
+		t.Errorf("p.Secrets[1].EnvironmentVariable = %q, want %q", *p.Secrets[1].EnvironmentVariable, "API_TOKEN")
+	}
+}
+
+func TestPipelineSecretsWithSteps(t *testing.T) {
+	t.Parallel()
+
+	// Test complete pipeline with both pipeline and step secrets
+	yamlData := `
+secrets:
+  - DATABASE_URL
+  - REDIS_URL
+steps:
+  - command: echo "step1"
+    secrets:
+      - API_TOKEN
+      - DATABASE_URL
+  - command: echo "step2"
+`
+
+	var p Pipeline
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(yamlData), &node)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err = ordered.Unmarshal(&node, &p)
+	if err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	// Check pipeline secrets
+	if len(p.Secrets) != 2 {
+		t.Fatalf("len(p.Secrets) = %d, want 2", len(p.Secrets))
+	}
+
+	// Check steps
+	if len(p.Steps) != 2 {
+		t.Fatalf("len(p.Steps) = %d, want 2", len(p.Steps))
+	}
+
+	// First step should have its own secrets
+	step1, ok := p.Steps[0].(*CommandStep)
+	if !ok {
+		t.Fatalf("p.Steps[0] is not a CommandStep")
+	}
+	if len(step1.Secrets) != 2 {
+		t.Fatalf("len(step1.Secrets) = %d, want 2", len(step1.Secrets))
+	}
+
+	// Second step should have no secrets initially
+	step2, ok := p.Steps[1].(*CommandStep)
+	if !ok {
+		t.Fatalf("p.Steps[1] is not a CommandStep")
+	}
+	if len(step2.Secrets) != 0 {
+		t.Fatalf("len(step2.Secrets) = %d, want 0", len(step2.Secrets))
+	}
+
+	// Test merging for both steps
+	step1.MergeSecretsFromPipeline(p.Secrets)
+	step2.MergeSecretsFromPipeline(p.Secrets)
+
+	// Step1 should have 3 secrets (2 from step + 1 from pipeline not overridden)
+	if len(step1.Secrets) != 3 {
+		t.Fatalf("len(step1.Secrets after merge) = %d, want 3", len(step1.Secrets))
+	}
+
+	// Step2 should have 2 secrets (both from pipeline)
+	if len(step2.Secrets) != 2 {
+		t.Fatalf("len(step2.Secrets after merge) = %d, want 2", len(step2.Secrets))
+	}
+}

--- a/pipeline_secrets_test.go
+++ b/pipeline_secrets_test.go
@@ -32,10 +32,6 @@ steps:
 		t.Fatalf("ordered.Unmarshal() error = %v", err)
 	}
 
-	if len(p.Secrets) != 2 {
-		t.Fatalf("len(p.Secrets) = %d, want 2", len(p.Secrets))
-	}
-
 	want := Secrets{
 		{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
 		{Key: "API_TOKEN", EnvironmentVariable: "API_TOKEN"},
@@ -74,9 +70,13 @@ steps:
 		t.Fatalf("ordered.Unmarshal() error = %v", err)
 	}
 
-	// Check pipeline secrets
-	if len(p.Secrets) != 2 {
-		t.Fatalf("len(p.Secrets) = %d, want 2", len(p.Secrets))
+	want := Secrets{
+		{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
+		{Key: "REDIS_URL", EnvironmentVariable: "REDIS_URL"},
+	}
+
+	if diff := cmp.Diff(want, p.Secrets); diff != "" {
+		t.Errorf("unexpected secrets (-want +got):\n%s", diff)
 	}
 
 	// Check steps

--- a/pipeline_secrets_test.go
+++ b/pipeline_secrets_test.go
@@ -36,7 +36,7 @@ steps:
 		t.Fatalf("len(p.Secrets) = %d, want 2", len(p.Secrets))
 	}
 
-	want := []Secret{
+	want := Secrets{
 		{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
 		{Key: "API_TOKEN", EnvironmentVariable: "API_TOKEN"},
 	}

--- a/pipeline_secrets_test.go
+++ b/pipeline_secrets_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/go-pipeline/ordered"
+	"github.com/google/go-cmp/cmp"
 	"gopkg.in/yaml.v3"
 )
 
@@ -35,20 +36,13 @@ steps:
 		t.Fatalf("len(p.Secrets) = %d, want 2", len(p.Secrets))
 	}
 
-	// Check first secret
-	if p.Secrets[0].Key != "DATABASE_URL" {
-		t.Errorf("p.Secrets[0].Key = %q, want %q", p.Secrets[0].Key, "DATABASE_URL")
-	}
-	if *p.Secrets[0].EnvironmentVariable != "DATABASE_URL" {
-		t.Errorf("p.Secrets[0].EnvironmentVariable = %q, want %q", *p.Secrets[0].EnvironmentVariable, "DATABASE_URL")
+	want := []Secret{
+		{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
+		{Key: "API_TOKEN", EnvironmentVariable: "API_TOKEN"},
 	}
 
-	// Check second secret
-	if p.Secrets[1].Key != "API_TOKEN" {
-		t.Errorf("p.Secrets[1].Key = %q, want %q", p.Secrets[1].Key, "API_TOKEN")
-	}
-	if *p.Secrets[1].EnvironmentVariable != "API_TOKEN" {
-		t.Errorf("p.Secrets[1].EnvironmentVariable = %q, want %q", *p.Secrets[1].EnvironmentVariable, "API_TOKEN")
+	if diff := cmp.Diff(p.Secrets, want); diff != "" {
+		t.Errorf("p.Secrets = %v, want %v", p.Secrets, want)
 	}
 }
 

--- a/secret.go
+++ b/secret.go
@@ -21,8 +21,7 @@ type Secret struct {
 
 // MarshalJSON marshals the secret to JSON.
 func (s *Secret) MarshalJSON() ([]byte, error) {
-	type secretAlias Secret
-	return json.Marshal((*secretAlias)(s))
+	return inlineFriendlyMarshalJSON(s)
 }
 
 func (s *Secret) interpolate(tf stringTransformer) error {

--- a/secret.go
+++ b/secret.go
@@ -3,14 +3,11 @@ package pipeline
 import (
 	"encoding/json"
 	"fmt"
-
-	"gopkg.in/yaml.v3"
 )
 
 var (
 	_ interface {
 		json.Marshaler
-		yaml.Marshaler
 		selfInterpolater
 	} = (*Secret)(nil)
 )
@@ -26,12 +23,6 @@ type Secret struct {
 func (s *Secret) MarshalJSON() ([]byte, error) {
 	type secretAlias Secret
 	return json.Marshal((*secretAlias)(s))
-}
-
-// MarshalYAML marshals the secret to YAML.
-func (s *Secret) MarshalYAML() (any, error) {
-	type secretAlias Secret
-	return (*secretAlias)(s), nil
 }
 
 func (s *Secret) interpolate(tf stringTransformer) error {

--- a/secret.go
+++ b/secret.go
@@ -15,7 +15,7 @@ var (
 // Secret represents a pipeline secret configuration.
 type Secret struct {
 	Key                 string         `json:"key" yaml:"key"`
-	EnvironmentVariable *string        `json:"environment_variable,omitempty" yaml:"environment_variable,omitempty"`
+	EnvironmentVariable string         `json:"environment_variable,omitempty" yaml:"environment_variable,omitempty"`
 	RemainingFields     map[string]any `yaml:",inline"`
 }
 
@@ -31,12 +31,12 @@ func (s *Secret) interpolate(tf stringTransformer) error {
 	}
 	s.Key = key
 
-	if s.EnvironmentVariable != nil {
-		envVar, err := tf.Transform(*s.EnvironmentVariable)
+	if s.EnvironmentVariable != "" {
+		envVar, err := tf.Transform(s.EnvironmentVariable)
 		if err != nil {
 			return fmt.Errorf("interpolating environment variable: %w", err)
 		}
-		s.EnvironmentVariable = &envVar
+		s.EnvironmentVariable = envVar
 	}
 
 	return nil

--- a/secret.go
+++ b/secret.go
@@ -20,7 +20,7 @@ type Secret struct {
 }
 
 // MarshalJSON marshals the secret to JSON.
-func (s *Secret) MarshalJSON() ([]byte, error) {
+func (s Secret) MarshalJSON() ([]byte, error) {
 	return inlineFriendlyMarshalJSON(s)
 }
 

--- a/secret.go
+++ b/secret.go
@@ -1,0 +1,53 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	_ interface {
+		json.Marshaler
+		yaml.Marshaler
+		selfInterpolater
+	} = (*Secret)(nil)
+)
+
+// Secret represents a pipeline secret configuration.
+type Secret struct {
+	Key                 string         `json:"key" yaml:"key"`
+	EnvironmentVariable *string        `json:"environment_variable,omitempty" yaml:"environment_variable,omitempty"`
+	RemainingFields     map[string]any `yaml:",inline"`
+}
+
+// MarshalJSON marshals the secret to JSON.
+func (s *Secret) MarshalJSON() ([]byte, error) {
+	type secretAlias Secret
+	return json.Marshal((*secretAlias)(s))
+}
+
+// MarshalYAML marshals the secret to YAML.
+func (s *Secret) MarshalYAML() (any, error) {
+	type secretAlias Secret
+	return (*secretAlias)(s), nil
+}
+
+func (s *Secret) interpolate(tf stringTransformer) error {
+	key, err := tf.Transform(s.Key)
+	if err != nil {
+		return fmt.Errorf("interpolating secret key: %w", err)
+	}
+	s.Key = key
+
+	if s.EnvironmentVariable != nil {
+		envVar, err := tf.Transform(*s.EnvironmentVariable)
+		if err != nil {
+			return fmt.Errorf("interpolating environment variable: %w", err)
+		}
+		s.EnvironmentVariable = &envVar
+	}
+
+	return nil
+}

--- a/secret_test.go
+++ b/secret_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/interpolate"
+	"github.com/google/go-cmp/cmp"
 	"gopkg.in/yaml.v3"
 )
 
@@ -12,9 +13,9 @@ func TestSecretMarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	envVar := "DATABASE_URL"
-	secret := &Secret{
+	secret := Secret{
 		Key:                 "DATABASE_URL",
-		EnvironmentVariable: &envVar,
+		EnvironmentVariable: envVar,
 	}
 
 	want := `{"environment_variable":"DATABASE_URL","key":"DATABASE_URL"}`
@@ -31,10 +32,9 @@ func TestSecretMarshalJSON(t *testing.T) {
 func TestSecretMarshalYAML(t *testing.T) {
 	t.Parallel()
 
-	envVar := "DATABASE_URL"
-	secret := &Secret{
+	secret := Secret{
 		Key:                 "DATABASE_URL",
-		EnvironmentVariable: &envVar,
+		EnvironmentVariable: "DATABASE_URL",
 	}
 
 	got, err := yaml.Marshal(secret)
@@ -51,10 +51,9 @@ func TestSecretMarshalYAML(t *testing.T) {
 func TestSecretInterpolation(t *testing.T) {
 	t.Parallel()
 
-	envVar := "${ENV_VAR_NAME}"
-	secret := &Secret{
+	secret := Secret{
 		Key:                 "${SECRET_NAME}",
-		EnvironmentVariable: &envVar,
+		EnvironmentVariable: "${ENV_VAR_NAME}",
 	}
 
 	tf := envInterpolator{
@@ -69,11 +68,12 @@ func TestSecretInterpolation(t *testing.T) {
 		t.Fatalf("secret.interpolate(%#v) error = %v", tf, err)
 	}
 
-	if secret.Key != "DATABASE_URL" {
-		t.Errorf("secret.Key = %q, want %q", secret.Key, "DATABASE_URL")
+	want := Secret{
+		Key:                 "DATABASE_URL",
+		EnvironmentVariable: "DB_CONNECTION",
 	}
 
-	if *secret.EnvironmentVariable != "DB_CONNECTION" {
-		t.Errorf("secret.EnvironmentVariable = %q, want %q", *secret.EnvironmentVariable, "DB_CONNECTION")
+	if diff := cmp.Diff(want, secret); diff != "" {
+		t.Errorf("secret.interpolate(%#v) = %s", tf, diff)
 	}
 }

--- a/secret_test.go
+++ b/secret_test.go
@@ -12,10 +12,9 @@ import (
 func TestSecretMarshalJSON(t *testing.T) {
 	t.Parallel()
 
-	envVar := "DATABASE_URL"
 	secret := Secret{
 		Key:                 "DATABASE_URL",
-		EnvironmentVariable: envVar,
+		EnvironmentVariable: "DATABASE_URL",
 	}
 
 	want := `{"environment_variable":"DATABASE_URL","key":"DATABASE_URL"}`

--- a/secret_test.go
+++ b/secret_test.go
@@ -17,7 +17,7 @@ func TestSecretMarshalJSON(t *testing.T) {
 		EnvironmentVariable: &envVar,
 	}
 
-	want := `{"key":"DATABASE_URL","environment_variable":"DATABASE_URL","RemainingFields":null}`
+	want := `{"environment_variable":"DATABASE_URL","key":"DATABASE_URL"}`
 	got, err := json.Marshal(secret)
 	if err != nil {
 		t.Fatalf("json.Marshal(%#v) error = %v", secret, err)

--- a/secret_test.go
+++ b/secret_test.go
@@ -73,6 +73,6 @@ func TestSecretInterpolation(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(want, secret); diff != "" {
-		t.Errorf("secret.interpolate(%#v) = %s", tf, diff)
+		t.Errorf("secret.interpolate(%#v) = %q, want: %q", tf, diff, want)
 	}
 }

--- a/secret_test.go
+++ b/secret_test.go
@@ -1,0 +1,79 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/buildkite/interpolate"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSecretMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	envVar := "DATABASE_URL"
+	secret := &Secret{
+		Key:                 "DATABASE_URL",
+		EnvironmentVariable: &envVar,
+	}
+
+	want := `{"key":"DATABASE_URL","environment_variable":"DATABASE_URL","RemainingFields":null}`
+	got, err := json.Marshal(secret)
+	if err != nil {
+		t.Fatalf("json.Marshal(%#v) error = %v", secret, err)
+	}
+
+	if string(got) != want {
+		t.Errorf("json.Marshal(%#v) = %q, want %q", secret, got, want)
+	}
+}
+
+func TestSecretMarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	envVar := "DATABASE_URL"
+	secret := &Secret{
+		Key:                 "DATABASE_URL",
+		EnvironmentVariable: &envVar,
+	}
+
+	got, err := yaml.Marshal(secret)
+	if err != nil {
+		t.Fatalf("yaml.Marshal(%#v) error = %v", secret, err)
+	}
+
+	want := "key: DATABASE_URL\nenvironment_variable: DATABASE_URL\n"
+	if string(got) != want {
+		t.Errorf("yaml.Marshal(%#v) = %q, want %q", secret, got, want)
+	}
+}
+
+func TestSecretInterpolation(t *testing.T) {
+	t.Parallel()
+
+	envVar := "${ENV_VAR_NAME}"
+	secret := &Secret{
+		Key:                 "${SECRET_NAME}",
+		EnvironmentVariable: &envVar,
+	}
+
+	tf := envInterpolator{
+		env: interpolate.NewMapEnv(map[string]string{
+			"SECRET_NAME":  "DATABASE_URL",
+			"ENV_VAR_NAME": "DB_CONNECTION",
+		}),
+	}
+
+	err := secret.interpolate(tf)
+	if err != nil {
+		t.Fatalf("secret.interpolate(%#v) error = %v", tf, err)
+	}
+
+	if secret.Key != "DATABASE_URL" {
+		t.Errorf("secret.Key = %q, want %q", secret.Key, "DATABASE_URL")
+	}
+
+	if *secret.EnvironmentVariable != "DB_CONNECTION" {
+		t.Errorf("secret.EnvironmentVariable = %q, want %q", *secret.EnvironmentVariable, "DB_CONNECTION")
+	}
+}

--- a/secrets.go
+++ b/secrets.go
@@ -1,0 +1,153 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/buildkite/go-pipeline/ordered"
+	"gopkg.in/yaml.v3"
+)
+
+var _ interface {
+	json.Unmarshaler
+	ordered.Unmarshaler
+} = (*Secrets)(nil)
+
+// Secrets is a sequence of secrets. It is useful for unmarshaling.
+type Secrets []*Secret
+
+// UnmarshalOrdered unmarshals Secrets from []any (sequence of secret names).
+func (s *Secrets) UnmarshalOrdered(o any) error {
+	switch o := o.(type) {
+	case nil:
+		// `secrets: null` is invalid - should be omitted entirely or use valid formats
+		return fmt.Errorf("unmarshaling secrets: secrets cannot be null")
+
+	case []any:
+		for _, c := range o {
+			switch ct := c.(type) {
+			case string:
+				secret := &Secret{
+					Key:                 ct,
+					EnvironmentVariable: &ct, // Default EnvironmentVariable to key value for simple string format
+				}
+				*s = append(*s, secret)
+
+			case map[string]any:
+				secret := &Secret{}
+
+				if key, ok := ct["key"].(string); ok {
+					secret.Key = key
+				}
+
+				if envVar, ok := ct["environment_variable"].(string); ok {
+					secret.EnvironmentVariable = &envVar
+				}
+
+				// Validate that we have at least a key
+				if secret.Key == "" {
+					return fmt.Errorf("unmarshaling secrets: secret object missing required 'key' field")
+				}
+
+				*s = append(*s, secret)
+
+			case *ordered.Map[string, interface{}]:
+				// Backend sends ordered.Map format
+				secret := &Secret{}
+
+				if keyVal, _ := ct.Get("key"); keyVal != nil {
+					if key, ok := keyVal.(string); ok {
+						secret.Key = key
+					}
+				}
+
+				if envVarVal, _ := ct.Get("environment_variable"); envVarVal != nil {
+					if envVar, ok := envVarVal.(string); ok {
+						secret.EnvironmentVariable = &envVar
+					}
+				}
+
+				// Keep environment_variable empty if not specified - don't auto-fill with key
+
+				// Validate that we have at least a key
+				if secret.Key == "" {
+					return fmt.Errorf("unmarshaling secrets: secret object missing required 'key' field")
+				}
+
+				*s = append(*s, secret)
+
+			default:
+				return fmt.Errorf("unmarshaling secrets: secret type %T, want string, map[string]any, or *ordered.Map", c)
+			}
+		}
+
+	default:
+		return fmt.Errorf("unmarshaling secrets: got %T, want []any", o)
+	}
+
+	return nil
+}
+
+// MergeWith merges these secrets with another set of secrets, with the other secrets taking precedence.
+// Deduplication is performed based on the EnvironmentVariable field.
+func (s Secrets) MergeWith(other Secrets) Secrets {
+	if len(s) == 0 {
+		return other
+	}
+	if len(other) == 0 {
+		return s
+	}
+
+	// Create a map to track environment variables we've seen for deduplication
+	seen := make(map[string]bool)
+	var result Secrets
+
+	for _, secret := range other {
+		if secret != nil && secret.EnvironmentVariable != nil && *secret.EnvironmentVariable != "" && !seen[*secret.EnvironmentVariable] {
+			result = append(result, secret)
+			seen[*secret.EnvironmentVariable] = true
+		}
+	}
+
+	for _, secret := range s {
+		if secret != nil && secret.EnvironmentVariable != nil && *secret.EnvironmentVariable != "" && !seen[*secret.EnvironmentVariable] {
+			result = append(result, secret)
+			seen[*secret.EnvironmentVariable] = true
+		}
+	}
+
+	return result
+}
+
+// UnmarshalJSON is used for JSON unmarshaling.
+func (s *Secrets) UnmarshalJSON(b []byte) error {
+	// JSON is just a specific kind of YAML.
+	var n yaml.Node
+	if err := yaml.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	return ordered.Unmarshal(&n, &s)
+}
+
+// MarshalYAML preserves the simple string format when possible.
+func (s Secrets) MarshalYAML() (interface{}, error) {
+	if len(s) == 0 {
+		return nil, nil
+	}
+
+	// Check if all secrets can be represented as simple strings
+	// (key == environment_variable and no other fields are set)
+	simpleStrings := make([]string, 0, len(s))
+	for _, secret := range s {
+		if secret != nil && secret.EnvironmentVariable != nil && secret.Key == *secret.EnvironmentVariable && secret.Key != "" {
+			simpleStrings = append(simpleStrings, secret.Key)
+		} else {
+			// If any secret can't be represented as a simple string,
+			// fall back to the full object representation
+			type secretAlias Secrets
+			return (secretAlias)(s), nil
+		}
+	}
+
+	return simpleStrings, nil
+}

--- a/secrets.go
+++ b/secrets.go
@@ -14,7 +14,7 @@ var _ interface {
 } = (*Secrets)(nil)
 
 // Secrets is a sequence of secrets. It is useful for unmarshaling.
-type Secrets []*Secret
+type Secrets []Secret
 
 // UnmarshalOrdered unmarshals Secrets from []any (sequence of secret names).
 func (s *Secrets) UnmarshalOrdered(o any) error {
@@ -27,21 +27,21 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 		for _, c := range o {
 			switch ct := c.(type) {
 			case string:
-				secret := &Secret{
+				secret := Secret{
 					Key:                 ct,
-					EnvironmentVariable: &ct, // Default EnvironmentVariable to key value for simple string format
+					EnvironmentVariable: ct, // Default EnvironmentVariable to key value for simple string format
 				}
 				*s = append(*s, secret)
 
 			case map[string]any:
-				secret := &Secret{}
+				secret := Secret{}
 
 				if key, ok := ct["key"].(string); ok {
 					secret.Key = key
 				}
 
 				if envVar, ok := ct["environment_variable"].(string); ok {
-					secret.EnvironmentVariable = &envVar
+					secret.EnvironmentVariable = envVar
 				}
 
 				// Validate that we have at least a key
@@ -53,7 +53,7 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 
 			case *ordered.Map[string, interface{}]:
 				// Backend sends ordered.Map format
-				secret := &Secret{}
+				secret := Secret{}
 
 				if keyVal, _ := ct.Get("key"); keyVal != nil {
 					if key, ok := keyVal.(string); ok {
@@ -63,7 +63,7 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 
 				if envVarVal, _ := ct.Get("environment_variable"); envVarVal != nil {
 					if envVar, ok := envVarVal.(string); ok {
-						secret.EnvironmentVariable = &envVar
+						secret.EnvironmentVariable = envVar
 					}
 				}
 
@@ -103,16 +103,16 @@ func (s Secrets) MergeWith(other Secrets) Secrets {
 	var result Secrets
 
 	for _, secret := range other {
-		if secret != nil && secret.EnvironmentVariable != nil && *secret.EnvironmentVariable != "" && !seen[*secret.EnvironmentVariable] {
+		if secret.EnvironmentVariable != "" && !seen[secret.EnvironmentVariable] {
 			result = append(result, secret)
-			seen[*secret.EnvironmentVariable] = true
+			seen[secret.EnvironmentVariable] = true
 		}
 	}
 
 	for _, secret := range s {
-		if secret != nil && secret.EnvironmentVariable != nil && *secret.EnvironmentVariable != "" && !seen[*secret.EnvironmentVariable] {
+		if secret.EnvironmentVariable != "" && !seen[secret.EnvironmentVariable] {
 			result = append(result, secret)
-			seen[*secret.EnvironmentVariable] = true
+			seen[secret.EnvironmentVariable] = true
 		}
 	}
 
@@ -139,7 +139,7 @@ func (s Secrets) MarshalYAML() (interface{}, error) {
 	// (key == environment_variable and no other fields are set)
 	simpleStrings := make([]string, 0, len(s))
 	for _, secret := range s {
-		if secret != nil && secret.EnvironmentVariable != nil && secret.Key == *secret.EnvironmentVariable && secret.Key != "" {
+		if secret.EnvironmentVariable != "" && secret.Key == secret.EnvironmentVariable && secret.Key != "" {
 			simpleStrings = append(simpleStrings, secret.Key)
 		} else {
 			// If any secret can't be represented as a simple string,

--- a/secrets.go
+++ b/secrets.go
@@ -130,25 +130,57 @@ func (s *Secrets) UnmarshalJSON(b []byte) error {
 	return ordered.Unmarshal(&n, &s)
 }
 
-// MarshalYAML preserves the simple string format when possible.
+// MarshalYAML returns the most appropriate YAML representation for the secrets.
+// It prioritizes simple string format, then map format, then full object format.
 func (s Secrets) MarshalYAML() (interface{}, error) {
 	if len(s) == 0 {
 		return nil, nil
 	}
 
-	// Check if all secrets can be represented as simple strings
-	// (key == environment_variable and no other fields are set)
-	simpleStrings := make([]string, 0, len(s))
-	for _, secret := range s {
-		if secret.EnvironmentVariable != "" && secret.Key == secret.EnvironmentVariable && secret.Key != "" {
-			simpleStrings = append(simpleStrings, secret.Key)
-		} else {
-			// If any secret can't be represented as a simple string,
-			// fall back to the full object representation
-			type secretAlias Secrets
-			return (secretAlias)(s), nil
+	// Use an array of strings if all secrets can be represented as simple strings (key equals environment variable)
+	if canMarshalAsSimpleStrings(s) {
+		result := make([]string, 0, len(s))
+		for _, secret := range s {
+			result = append(result, secret.Key)
 		}
+		return result, nil
 	}
 
-	return simpleStrings, nil
+	// Use a map if all secrets have different key and environment variable.
+	if canMarshalAsMap(s) {
+		result := make(map[string]string, len(s))
+		for _, secret := range s {
+			result[secret.EnvironmentVariable] = secret.Key
+		}
+		return result, nil
+	}
+
+	// Fall back to full object format.
+	result := make([]Secret, len(s))
+	copy(result, s)
+	return result, nil
+}
+
+// canMarshalAsSimpleStrings reports whether all secrets can be represented
+// as simple strings (key equals environment variable).
+func canMarshalAsSimpleStrings(secrets Secrets) bool {
+	for _, secret := range secrets {
+		if secret.EnvironmentVariable == "" ||
+			secret.Key != secret.EnvironmentVariable ||
+			len(secret.RemainingFields) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// canMarshalAsMap reports whether all secrets can be represented
+// as key-value map format (all have non-empty environment variables and no remaining fields).
+func canMarshalAsMap(secrets Secrets) bool {
+	for _, secret := range secrets {
+		if secret.EnvironmentVariable == "" || len(secret.RemainingFields) > 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/secrets.go
+++ b/secrets.go
@@ -24,9 +24,9 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 		// `secrets: null` is invalid - should be omitted entirely or use valid formats
 		return fmt.Errorf("unmarshaling secrets: secrets cannot be null")
 
-	case *ordered.Map[string, interface{}]:
+	case *ordered.Map[string, any]:
 		// Handle map syntax: {"ENV_VAR": "SECRET_KEY"}
-		return o.Range(func(envVar string, secretKeyVal interface{}) error {
+		return o.Range(func(envVar string, secretKeyVal any) error {
 			secretKey, ok := secretKeyVal.(string)
 			if !ok {
 				return fmt.Errorf("unmarshaling secrets: secret key must be a string, but was %T", secretKeyVal)

--- a/secrets.go
+++ b/secrets.go
@@ -39,11 +39,11 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 
 				keyVal, _ := ct.Get("key")
 				// Still need two values on the left side to avoid panic
-   			key, _ := keyVal.(string)
-   			if key == "" {
-   				return fmt.Errorf("unmarshaling secret: key must be a non-empty string, but was %[1]T %[1]q", keyVal)
-   			}
-   			secret.Key = key
+				key, _ := keyVal.(string)
+				if key == "" {
+					return fmt.Errorf("unmarshaling secret: key must be a non-empty string, but was %[1]T %[1]q", keyVal)
+				}
+				secret.Key = key
 
 				if envVarVal, _ := ct.Get("environment_variable"); envVarVal != nil {
 					if envVar, ok := envVarVal.(string); ok {
@@ -52,7 +52,6 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 				}
 
 				// Keep environment_variable empty if not specified - don't auto-fill with key
-
 				// Validate that we have at least a key
 				if secret.Key == "" {
 					return fmt.Errorf("unmarshaling secrets: secret object missing required 'key' field")

--- a/secrets.go
+++ b/secrets.go
@@ -38,7 +38,6 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 				secret := Secret{}
 
 				keyVal, _ := ct.Get("key")
-				// Still need two values on the left side to avoid panic
 				key, _ := keyVal.(string)
 				if key == "" {
 					return fmt.Errorf("unmarshaling secret: key must be a non-empty string, but was %[1]T %[1]q", keyVal)

--- a/secrets.go
+++ b/secrets.go
@@ -37,11 +37,13 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 				// Backend sends ordered.Map format
 				secret := Secret{}
 
-				if keyVal, _ := ct.Get("key"); keyVal != nil {
-					if key, ok := keyVal.(string); ok {
-						secret.Key = key
-					}
-				}
+				keyVal, _ := ct.Get("key")
+				// Still need two values on the left side to avoid panic
+   			key, _ := keyVal.(string)
+   			if key == "" {
+   				return fmt.Errorf("unmarshaling secret: key must be a non-empty string, but was %[1]T %[1]q", keyVal)
+   			}
+   			secret.Key = key
 
 				if envVarVal, _ := ct.Get("environment_variable"); envVarVal != nil {
 					if envVar, ok := envVarVal.(string); ok {

--- a/secrets.go
+++ b/secrets.go
@@ -11,6 +11,7 @@ import (
 var _ interface {
 	json.Unmarshaler
 	ordered.Unmarshaler
+	yaml.Marshaler
 } = (*Secrets)(nil)
 
 // Secrets is a sequence of secrets. It is useful for unmarshaling.

--- a/secrets.go
+++ b/secrets.go
@@ -146,7 +146,7 @@ func (s Secrets) MarshalYAML() (interface{}, error) {
 		return result, nil
 	}
 
-	// Use a map if all secrets have different key and environment variable.
+	// Otherwise, use { ENV_VAR:SECRET_NAME } map format if secrets have no other fields
 	if canMarshalAsMap(s) {
 		result := make(map[string]string, len(s))
 		for _, secret := range s {

--- a/secrets.go
+++ b/secrets.go
@@ -162,9 +162,7 @@ func (s Secrets) MarshalYAML() (interface{}, error) {
 
 func canMarshalAsSimpleStrings(secrets Secrets) bool {
 	for _, secret := range secrets {
-		if secret.EnvironmentVariable == "" ||
-			secret.Key != secret.EnvironmentVariable ||
-			len(secret.RemainingFields) > 0 {
+		if secret.EnvironmentVariable == "" || secret.Key != secret.EnvironmentVariable || len(secret.RemainingFields) > 0 {
 			return false
 		}
 	}

--- a/secrets.go
+++ b/secrets.go
@@ -161,8 +161,6 @@ func (s Secrets) MarshalYAML() (interface{}, error) {
 	return result, nil
 }
 
-// canMarshalAsSimpleStrings reports whether all secrets can be represented
-// as simple strings (key equals environment variable).
 func canMarshalAsSimpleStrings(secrets Secrets) bool {
 	for _, secret := range secrets {
 		if secret.EnvironmentVariable == "" ||
@@ -174,8 +172,6 @@ func canMarshalAsSimpleStrings(secrets Secrets) bool {
 	return true
 }
 
-// canMarshalAsMap reports whether all secrets can be represented
-// as key-value map format (all have non-empty environment variables and no remaining fields).
 func canMarshalAsMap(secrets Secrets) bool {
 	for _, secret := range secrets {
 		if secret.EnvironmentVariable == "" || len(secret.RemainingFields) > 0 {

--- a/secrets.go
+++ b/secrets.go
@@ -46,15 +46,11 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 				secret.Key = key
 
 				if envVarVal, _ := ct.Get("environment_variable"); envVarVal != nil {
-					if envVar, ok := envVarVal.(string); ok {
-						secret.EnvironmentVariable = envVar
+					envVar, ok := envVarVal.(string)
+					if !ok {
+						return fmt.Errorf("unmarshaling secret: environment_variable must be a string, but was %T", envVarVal)
 					}
-				}
-
-				// Keep environment_variable empty if not specified - don't auto-fill with key
-				// Validate that we have at least a key
-				if secret.Key == "" {
-					return fmt.Errorf("unmarshaling secrets: secret object missing required 'key' field")
+					secret.EnvironmentVariable = envVar
 				}
 
 				*s = append(*s, secret)

--- a/secrets.go
+++ b/secrets.go
@@ -24,6 +24,28 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 		// `secrets: null` is invalid - should be omitted entirely or use valid formats
 		return fmt.Errorf("unmarshaling secrets: secrets cannot be null")
 
+	case *ordered.Map[string, interface{}]:
+		// Handle map syntax: {"ENV_VAR": "SECRET_KEY"}
+		return o.Range(func(envVar string, secretKeyVal interface{}) error {
+			secretKey, ok := secretKeyVal.(string)
+			if !ok {
+				return fmt.Errorf("unmarshaling secrets: secret key must be a string, but was %T", secretKeyVal)
+			}
+			if secretKey == "" {
+				return fmt.Errorf("unmarshaling secrets: secret key cannot be empty")
+			}
+			if envVar == "" {
+				return fmt.Errorf("unmarshaling secrets: environment variable name cannot be empty")
+			}
+
+			secret := Secret{
+				Key:                 secretKey,
+				EnvironmentVariable: envVar,
+			}
+			*s = append(*s, secret)
+			return nil
+		})
+
 	case []any:
 		for _, c := range o {
 			switch ct := c.(type) {
@@ -41,7 +63,7 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 				keyVal, _ := ct.Get("key")
 				key, _ := keyVal.(string)
 				if key == "" {
-					return fmt.Errorf("unmarshaling secret: key must be a non-empty string, but was %[1]T %[1]q", keyVal)
+					return fmt.Errorf("unmarshaling secret: key must be a non-empty string, but was %[1]T %[1]v", keyVal)
 				}
 				secret.Key = key
 
@@ -61,7 +83,7 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 		}
 
 	default:
-		return fmt.Errorf("unmarshaling secrets: got %T, want []any", o)
+		return fmt.Errorf("unmarshaling secrets: got %T, want []any or map[string]any", o)
 	}
 
 	return nil

--- a/secrets.go
+++ b/secrets.go
@@ -131,7 +131,7 @@ func (s *Secrets) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalYAML returns the most appropriate YAML representation for the secrets.
-// It prioritizes simple string format, then map format, then full object format.
+// It prioritizes simple string format, then map format, then returns an error for invalid configurations.
 func (s Secrets) MarshalYAML() (interface{}, error) {
 	if len(s) == 0 {
 		return nil, nil
@@ -155,10 +155,9 @@ func (s Secrets) MarshalYAML() (interface{}, error) {
 		return result, nil
 	}
 
-	// Fall back to full object format.
-	result := make([]Secret, len(s))
-	copy(result, s)
-	return result, nil
+	// Cannot represent secrets in user-facing YAML format.
+	// This happens when secrets have RemainingFields or empty EnvironmentVariable.
+	return nil, fmt.Errorf("cannot marshal secrets to YAML: contains secrets with unsupported fields or empty environment variables")
 }
 
 func canMarshalAsSimpleStrings(secrets Secrets) bool {

--- a/secrets.go
+++ b/secrets.go
@@ -33,24 +33,6 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 				}
 				*s = append(*s, secret)
 
-			case map[string]any:
-				secret := Secret{}
-
-				if key, ok := ct["key"].(string); ok {
-					secret.Key = key
-				}
-
-				if envVar, ok := ct["environment_variable"].(string); ok {
-					secret.EnvironmentVariable = envVar
-				}
-
-				// Validate that we have at least a key
-				if secret.Key == "" {
-					return fmt.Errorf("unmarshaling secrets: secret object missing required 'key' field")
-				}
-
-				*s = append(*s, secret)
-
 			case *ordered.Map[string, interface{}]:
 				// Backend sends ordered.Map format
 				secret := Secret{}

--- a/secrets.go
+++ b/secrets.go
@@ -130,50 +130,12 @@ func (s *Secrets) UnmarshalJSON(b []byte) error {
 	return ordered.Unmarshal(&n, &s)
 }
 
-// MarshalYAML returns the most appropriate YAML representation for the secrets.
-// It prioritizes simple string format, then map format, then returns an error for invalid configurations.
-func (s Secrets) MarshalYAML() (interface{}, error) {
+func (s Secrets) MarshalYAML() (any, error) {
 	if len(s) == 0 {
 		return nil, nil
 	}
 
-	// Use an array of strings if all secrets can be represented as simple strings (key equals environment variable)
-	if canMarshalAsSimpleStrings(s) {
-		result := make([]string, 0, len(s))
-		for _, secret := range s {
-			result = append(result, secret.Key)
-		}
-		return result, nil
-	}
-
-	// Otherwise, use { ENV_VAR:SECRET_NAME } map format if secrets have no other fields
-	if canMarshalAsMap(s) {
-		result := make(map[string]string, len(s))
-		for _, secret := range s {
-			result[secret.EnvironmentVariable] = secret.Key
-		}
-		return result, nil
-	}
-
-	// Cannot represent secrets in user-facing YAML format.
-	// This happens when secrets have RemainingFields or empty EnvironmentVariable.
-	return nil, fmt.Errorf("cannot marshal secrets to YAML: contains secrets with unsupported fields or empty environment variables")
-}
-
-func canMarshalAsSimpleStrings(secrets Secrets) bool {
-	for _, secret := range secrets {
-		if secret.EnvironmentVariable == "" || secret.Key != secret.EnvironmentVariable || len(secret.RemainingFields) > 0 {
-			return false
-		}
-	}
-	return true
-}
-
-func canMarshalAsMap(secrets Secrets) bool {
-	for _, secret := range secrets {
-		if secret.EnvironmentVariable == "" || len(secret.RemainingFields) > 0 {
-			return false
-		}
-	}
-	return true
+	result := make([]Secret, len(s))
+	copy(result, s)
+	return result, nil
 }

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -184,3 +184,254 @@ func TestSecretsMergeWithEmptySlices(t *testing.T) {
 		t.Errorf("merged3 mismatch (-got +want):\n%s", diff)
 	}
 }
+
+func TestSecretsUnmarshalMapSyntax(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+CUSTOM_ENV: SECRET_KEY
+API_TOKEN: api-secret
+DATABASE_URL: db-key
+`
+
+	var secrets Secrets
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(yamlData), &node)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err = ordered.Unmarshal(&node, &secrets)
+	if err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	want := Secrets{
+		Secret{Key: "SECRET_KEY", EnvironmentVariable: "CUSTOM_ENV"},
+		Secret{Key: "api-secret", EnvironmentVariable: "API_TOKEN"},
+		Secret{Key: "db-key", EnvironmentVariable: "DATABASE_URL"},
+	}
+
+	if diff := cmp.Diff(secrets, want); diff != "" {
+		t.Errorf("secrets mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestSecretsUnmarshalMapSyntaxJSON(t *testing.T) {
+	t.Parallel()
+
+	jsonData := `{
+		"CUSTOM_ENV": "SECRET_KEY",
+		"API_TOKEN": "api-secret"
+	}`
+
+	var secrets Secrets
+	err := json.Unmarshal([]byte(jsonData), &secrets)
+	if err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	want := Secrets{
+		Secret{Key: "SECRET_KEY", EnvironmentVariable: "CUSTOM_ENV"},
+		Secret{Key: "api-secret", EnvironmentVariable: "API_TOKEN"},
+	}
+
+	if diff := cmp.Diff(secrets, want); diff != "" {
+		t.Errorf("secrets mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestSecretsUnmarshalMapSyntaxErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		yamlData    string
+		expectedErr string
+	}{
+		{
+			name:        "non-string secret key",
+			yamlData:    "ENV_VAR: 123",
+			expectedErr: "unmarshaling secrets: secret key must be a string, but was int",
+		},
+		{
+			name:        "empty secret key",
+			yamlData:    "ENV_VAR: \"\"",
+			expectedErr: "unmarshaling secrets: secret key cannot be empty",
+		},
+		{
+			name:        "empty environment variable name",
+			yamlData:    "\"\": SECRET_KEY",
+			expectedErr: "unmarshaling secrets: environment variable name cannot be empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var secrets Secrets
+			var node yaml.Node
+			err := yaml.Unmarshal([]byte(tc.yamlData), &node)
+			if err != nil {
+				t.Fatalf("yaml.Unmarshal() error = %v", err)
+			}
+
+			err = ordered.Unmarshal(&node, &secrets)
+			if err == nil {
+				t.Fatalf("ordered.Unmarshal() should return error, got nil")
+			}
+
+			if err.Error() != tc.expectedErr {
+				t.Errorf("ordered.Unmarshal() error = %q, want %q", err.Error(), tc.expectedErr)
+			}
+		})
+	}
+}
+
+func TestSecretsUnmarshalMixedFormats(t *testing.T) {
+	t.Parallel()
+
+	// Test that array and map formats can't be mixed at the top level
+	// This should use the array format (existing behavior)
+	yamlData := `
+- DATABASE_URL
+- key: API_TOKEN
+  environment_variable: API_KEY
+`
+
+	var secrets Secrets
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(yamlData), &node)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err = ordered.Unmarshal(&node, &secrets)
+	if err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	want := Secrets{
+		Secret{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
+		Secret{Key: "API_TOKEN", EnvironmentVariable: "API_KEY"},
+	}
+
+	if diff := cmp.Diff(secrets, want); diff != "" {
+		t.Errorf("secrets mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestSecretsUnmarshalEmptyMap(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `{}`
+
+	var secrets Secrets
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(yamlData), &node)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err = ordered.Unmarshal(&node, &secrets)
+	if err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	if secrets != nil && len(secrets) != 0 {
+		t.Errorf("Expected empty secrets, got %v", secrets)
+	}
+}
+
+func TestSecretsMapSyntaxPreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+FIRST: first-key
+SECOND: second-key
+THIRD: third-key
+`
+
+	var secrets Secrets
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(yamlData), &node)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err = ordered.Unmarshal(&node, &secrets)
+	if err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	// Verify order is preserved
+	want := Secrets{
+		Secret{Key: "first-key", EnvironmentVariable: "FIRST"},
+		Secret{Key: "second-key", EnvironmentVariable: "SECOND"},
+		Secret{Key: "third-key", EnvironmentVariable: "THIRD"},
+	}
+
+	if diff := cmp.Diff(secrets, want); diff != "" {
+		t.Errorf("secrets mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestSecretsInvalidFormatErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		yamlData    string
+		expectedErr string
+	}{
+		{
+			name:        "invalid array item type",
+			yamlData:    "- 123",
+			expectedErr: "unmarshaling secrets: secret type int, want string, map[string]any, or *ordered.Map",
+		},
+		{
+			name:        "backend format with invalid key type",
+			yamlData:    "- key: 123",
+			expectedErr: "unmarshaling secret: key must be a non-empty string, but was int 123",
+		},
+		{
+			name:        "backend format with empty key",
+			yamlData:    "- key: \"\"",
+			expectedErr: "unmarshaling secret: key must be a non-empty string, but was string ",
+		},
+		{
+			name:        "backend format with invalid environment_variable type",
+			yamlData:    "- key: test\n  environment_variable: 123",
+			expectedErr: "unmarshaling secret: environment_variable must be a string, but was int",
+		},
+		{
+			name:        "invalid top-level type",
+			yamlData:    "\"invalid\"",
+			expectedErr: "unmarshaling secrets: got string, want []any or map[string]any",
+		},
+		{
+			name:        "invalid top-level number",
+			yamlData:    "123",
+			expectedErr: "unmarshaling secrets: got int, want []any or map[string]any",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var secrets Secrets
+			var node yaml.Node
+			err := yaml.Unmarshal([]byte(tc.yamlData), &node)
+			if err != nil {
+				t.Fatalf("yaml.Unmarshal() error = %v", err)
+			}
+
+			err = ordered.Unmarshal(&node, &secrets)
+			if err == nil {
+				t.Fatalf("ordered.Unmarshal() should return error, got nil")
+			}
+
+			if err.Error() != tc.expectedErr {
+				t.Errorf("ordered.Unmarshal() error = %q, want %q", err.Error(), tc.expectedErr)
+			}
+		})
+	}
+}

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -397,6 +397,32 @@ func TestSecretsBackwardCompatibility(t *testing.T) {
 			},
 		},
 		{
+			name: "simple map format",
+			yamlData: `
+DATABASE_URL: DATABASE_URL
+API_TOKEN: API_TOKEN
+REDIS_URL: REDIS_URL
+`,
+			want: Secrets{
+				Secret{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
+				Secret{Key: "API_TOKEN", EnvironmentVariable: "API_TOKEN"},
+				Secret{Key: "REDIS_URL", EnvironmentVariable: "REDIS_URL"},
+			},
+		},
+		{
+			name: "complex map format (different keys)",
+			yamlData: `
+DIRECT_DATABASE_URL: DATABASE_URL
+BUILDKITE_API_TOKEN: API_TOKEN
+REDIS_URL_DIRECT: REDIS_URL
+`,
+			want: Secrets{
+				Secret{Key: "DATABASE_URL", EnvironmentVariable: "DIRECT_DATABASE_URL"},
+				Secret{Key: "API_TOKEN", EnvironmentVariable: "BUILDKITE_API_TOKEN"},
+				Secret{Key: "REDIS_URL", EnvironmentVariable: "REDIS_URL_DIRECT"},
+			},
+		},
+		{
 			name: "backend object format",
 			yamlData: `
 - key: database-secret
@@ -516,34 +542,6 @@ func TestSecretsInvalidFormatErrors(t *testing.T) {
 	}
 }
 
-func TestSecretsMarshalYAMLMapSyntax(t *testing.T) {
-	t.Parallel()
-
-	secrets := Secrets{
-		Secret{Key: "database-secret-key", EnvironmentVariable: "DATABASE_URL"},
-		Secret{Key: "api-secret-key", EnvironmentVariable: "API_TOKEN"},
-	}
-
-	yamlData, err := secrets.MarshalYAML()
-	if err != nil {
-		t.Fatalf("MarshalYAML() error = %v", err)
-	}
-
-	mapData, ok := yamlData.(map[string]string)
-	if !ok {
-		t.Fatalf("MarshalYAML() returned %T, want map[string]string", yamlData)
-	}
-
-	want := map[string]string{
-		"DATABASE_URL": "database-secret-key",
-		"API_TOKEN":    "api-secret-key",
-	}
-
-	if diff := cmp.Diff(mapData, want); diff != "" {
-		t.Errorf("map format mismatch (-got +want):\n%s", diff)
-	}
-}
-
 func TestSecretsUnmarshalMapFormat(t *testing.T) {
 	t.Parallel()
 
@@ -571,6 +569,80 @@ API_TOKEN: api-secret-key
 
 	if diff := cmp.Diff(secrets, want); diff != "" {
 		t.Errorf("map format unmarshaling mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestSecretsMarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	secrets := Secrets{
+		Secret{Key: "database-secret-key", EnvironmentVariable: "DATABASE_URL"},
+		Secret{Key: "api-secret-key", EnvironmentVariable: "API_TOKEN"},
+	}
+
+	// Test that it actually marshals to the expected YAML format
+	actualYAML, err := yaml.Marshal(secrets)
+	if err != nil {
+		t.Fatalf("yaml.Marshal() error = %v", err)
+	}
+
+	expectedYAML := `- key: database-secret-key
+  environment_variable: DATABASE_URL
+- key: api-secret-key
+  environment_variable: API_TOKEN
+`
+
+	if string(actualYAML) != expectedYAML {
+		t.Errorf("YAML output mismatch:\nGot:\n%s\nWant:\n%s", string(actualYAML), expectedYAML)
+	}
+}
+
+func TestSecretsMarshalYAMLEmptyEnvironmentVariable(t *testing.T) {
+	t.Parallel()
+
+	secrets := Secrets{
+		Secret{Key: "database-secret-key", EnvironmentVariable: ""},
+		Secret{Key: "api-secret-key", EnvironmentVariable: "API_TOKEN"},
+	}
+
+	// Test that it actually marshals to the expected YAML format
+	actualYAML, err := yaml.Marshal(secrets)
+	if err != nil {
+		t.Fatalf("yaml.Marshal() error = %v", err)
+	}
+
+	expectedYAML := `- key: database-secret-key
+- key: api-secret-key
+  environment_variable: API_TOKEN
+`
+
+	if string(actualYAML) != expectedYAML {
+		t.Errorf("YAML output mismatch:\nGot:\n%s\nWant:\n%s", string(actualYAML), expectedYAML)
+	}
+}
+
+func TestSecretsMarshalYAMLEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	secrets := Secrets{
+		Secret{Key: "", EnvironmentVariable: "ENV_VARIABLE"},
+		Secret{Key: "api-secret-key", EnvironmentVariable: "API_TOKEN"},
+	}
+
+	// Test that it actually marshals to the expected YAML format
+	actualYAML, err := yaml.Marshal(secrets)
+	if err != nil {
+		t.Fatalf("yaml.Marshal() error = %v", err)
+	}
+
+	expectedYAML := `- key: ""
+  environment_variable: ENV_VARIABLE
+- key: api-secret-key
+  environment_variable: API_TOKEN
+`
+
+	if string(actualYAML) != expectedYAML {
+		t.Errorf("YAML output mismatch:\nGot:\n%s\nWant:\n%s", string(actualYAML), expectedYAML)
 	}
 }
 
@@ -612,13 +684,8 @@ func TestSecretsMarshalYAMLUnsupportedConfiguration(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := tc.secrets.MarshalYAML()
-			if err == nil {
+			if err != nil {
 				t.Fatalf("MarshalYAML() should return error for unsupported configuration, got nil")
-			}
-
-			expectedErr := "cannot marshal secrets to YAML: contains secrets with unsupported fields or empty environment variables"
-			if err.Error() != expectedErr {
-				t.Errorf("MarshalYAML() error = %q, want %q", err.Error(), expectedErr)
 			}
 		})
 	}

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -1,0 +1,201 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/buildkite/go-pipeline/ordered"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSecretsUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	jsonData := `[
+		"DATABASE_URL",
+		"API_TOKEN"
+	]`
+
+	var secrets Secrets
+	err := json.Unmarshal([]byte(jsonData), &secrets)
+	if err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if len(secrets) != 2 {
+		t.Fatalf("len(secrets) = %d, want 2", len(secrets))
+	}
+
+	// Check first secret
+	if secrets[0].Key != "DATABASE_URL" {
+		t.Errorf("secrets[0].Key = %q, want %q", secrets[0].Key, "DATABASE_URL")
+	}
+	if *secrets[0].EnvironmentVariable != "DATABASE_URL" {
+		t.Errorf("secrets[0].EnvironmentVariable = %q, want %q", *secrets[0].EnvironmentVariable, "DATABASE_URL")
+	}
+
+	// Check second secret
+	if secrets[1].Key != "API_TOKEN" {
+		t.Errorf("secrets[1].Key = %q, want %q", secrets[1].Key, "API_TOKEN")
+	}
+	if *secrets[1].EnvironmentVariable != "API_TOKEN" {
+		t.Errorf("secrets[1].EnvironmentVariable = %q, want %q", *secrets[1].EnvironmentVariable, "API_TOKEN")
+	}
+}
+
+func TestSecretsUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+- DATABASE_URL
+- API_TOKEN
+`
+
+	var secrets Secrets
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(yamlData), &node)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err = ordered.Unmarshal(&node, &secrets)
+	if err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	if len(secrets) != 2 {
+		t.Fatalf("len(secrets) = %d, want 2", len(secrets))
+	}
+
+	// Check first secret
+	if secrets[0].Key != "DATABASE_URL" {
+		t.Errorf("secrets[0].Key = %q, want %q", secrets[0].Key, "DATABASE_URL")
+	}
+	if *secrets[0].EnvironmentVariable != "DATABASE_URL" {
+		t.Errorf("secrets[0].EnvironmentVariable = %q, want %q", *secrets[0].EnvironmentVariable, "DATABASE_URL")
+	}
+
+	// Check second secret
+	if secrets[1].Key != "API_TOKEN" {
+		t.Errorf("secrets[1].Key = %q, want %q", secrets[1].Key, "API_TOKEN")
+	}
+	if *secrets[1].EnvironmentVariable != "API_TOKEN" {
+		t.Errorf("secrets[1].EnvironmentVariable = %q, want %q", *secrets[1].EnvironmentVariable, "API_TOKEN")
+	}
+}
+
+func TestSecretsUnmarshalNull(t *testing.T) {
+	t.Parallel()
+
+	var secrets Secrets
+	err := secrets.UnmarshalOrdered(nil)
+	if err == nil {
+		t.Fatalf("UnmarshalOrdered(nil) should return error, got nil")
+	}
+
+	expectedErr := "unmarshaling secrets: secrets cannot be null"
+	if err.Error() != expectedErr {
+		t.Errorf("UnmarshalOrdered(nil) error = %q, want %q", err.Error(), expectedErr)
+	}
+}
+
+func TestSecretsUnmarshalNullYAML(t *testing.T) {
+	t.Parallel()
+
+	// Test that `secrets: null` in YAML returns an error
+	yamlData := `null`
+
+	var secrets Secrets
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(yamlData), &node)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err = ordered.Unmarshal(&node, &secrets)
+	if err == nil {
+		t.Fatalf("ordered.Unmarshal() should return error for null secrets, got nil")
+	}
+
+	expectedErr := "unmarshaling secrets: secrets cannot be null"
+	if err.Error() != expectedErr {
+		t.Errorf("ordered.Unmarshal() error = %q, want %q", err.Error(), expectedErr)
+	}
+}
+
+func TestSecretsMergeWith(t *testing.T) {
+	t.Parallel()
+
+	// Test basic merging functionality
+	dbUrl := "DATABASE_URL"
+	redisUrl := "REDIS_URL"
+	apiToken := "API_TOKEN"
+	dbUrlOverride := "DATABASE_URL"
+
+	baseSecrets := Secrets{
+		&Secret{Key: "DB_KEY", EnvironmentVariable: &dbUrl},
+		&Secret{Key: "REDIS_KEY", EnvironmentVariable: &redisUrl},
+	}
+
+	stepSecrets := Secrets{
+		&Secret{Key: "API_KEY", EnvironmentVariable: &apiToken},
+		&Secret{Key: "DB_OVERRIDE", EnvironmentVariable: &dbUrlOverride}, // Should override base
+	}
+
+	merged := baseSecrets.MergeWith(stepSecrets)
+
+	if len(merged) != 3 {
+		t.Fatalf("len(merged) = %d, want 3", len(merged))
+	}
+
+	// Step secrets should come first and take precedence
+	if merged[0].Key != "API_KEY" || *merged[0].EnvironmentVariable != "API_TOKEN" {
+		t.Errorf("merged[0] = Key:%q, EnvVar:%q, want Key:%q, EnvVar:%q",
+			merged[0].Key, *merged[0].EnvironmentVariable, "API_KEY", "API_TOKEN")
+	}
+
+	// DATABASE_URL should use step override, not base
+	if merged[1].Key != "DB_OVERRIDE" || *merged[1].EnvironmentVariable != "DATABASE_URL" {
+		t.Errorf("merged[1] = Key:%q, EnvVar:%q, want Key:%q, EnvVar:%q",
+			merged[1].Key, *merged[1].EnvironmentVariable, "DB_OVERRIDE", "DATABASE_URL")
+	}
+
+	// REDIS_URL should come from base (no override)
+	if merged[2].Key != "REDIS_KEY" || *merged[2].EnvironmentVariable != "REDIS_URL" {
+		t.Errorf("merged[2] = Key:%q, EnvVar:%q, want Key:%q, EnvVar:%q",
+			merged[2].Key, *merged[2].EnvironmentVariable, "REDIS_KEY", "REDIS_URL")
+	}
+}
+
+func TestSecretsMergeWithEmptySlices(t *testing.T) {
+	t.Parallel()
+
+	dbUrl := "DATABASE_URL"
+	baseSecrets := Secrets{
+		&Secret{Key: "DB_KEY", EnvironmentVariable: &dbUrl},
+	}
+
+	// Empty other should return base
+	merged1 := baseSecrets.MergeWith(Secrets{})
+	if len(merged1) != 1 {
+		t.Fatalf("len(merged1) = %d, want 1", len(merged1))
+	}
+	if merged1[0].Key != "DB_KEY" {
+		t.Errorf("merged1[0].Key = %q, want %q", merged1[0].Key, "DB_KEY")
+	}
+
+	// Empty base should return other
+	merged2 := Secrets{}.MergeWith(baseSecrets)
+	if len(merged2) != 1 {
+		t.Fatalf("len(merged2) = %d, want 1", len(merged2))
+	}
+	if merged2[0].Key != "DB_KEY" {
+		t.Errorf("merged2[0].Key = %q, want %q", merged2[0].Key, "DB_KEY")
+	}
+
+	// Both empty should return empty
+	merged3 := Secrets{}.MergeWith(Secrets{})
+	if len(merged3) != 0 {
+		t.Fatalf("len(merged3) = %d, want 0", len(merged3))
+	}
+}

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -18,7 +18,7 @@ func TestSecretsUnmarshalJSON(t *testing.T) {
 	]`
 
 	var secrets Secrets
-	err := json.Unmarshal([]byte(jsonData), secrets)
+	err := json.Unmarshal([]byte(jsonData), &secrets)
 	if err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/go-pipeline/ordered"
+	"github.com/google/go-cmp/cmp"
 	"gopkg.in/yaml.v3"
 )
 
@@ -17,7 +18,7 @@ func TestSecretsUnmarshalJSON(t *testing.T) {
 	]`
 
 	var secrets Secrets
-	err := json.Unmarshal([]byte(jsonData), &secrets)
+	err := json.Unmarshal([]byte(jsonData), secrets)
 	if err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
@@ -30,16 +31,16 @@ func TestSecretsUnmarshalJSON(t *testing.T) {
 	if secrets[0].Key != "DATABASE_URL" {
 		t.Errorf("secrets[0].Key = %q, want %q", secrets[0].Key, "DATABASE_URL")
 	}
-	if *secrets[0].EnvironmentVariable != "DATABASE_URL" {
-		t.Errorf("secrets[0].EnvironmentVariable = %q, want %q", *secrets[0].EnvironmentVariable, "DATABASE_URL")
+	if secrets[0].EnvironmentVariable != "DATABASE_URL" {
+		t.Errorf("secrets[0].EnvironmentVariable = %q, want %q", secrets[0].EnvironmentVariable, "DATABASE_URL")
 	}
 
 	// Check second secret
 	if secrets[1].Key != "API_TOKEN" {
 		t.Errorf("secrets[1].Key = %q, want %q", secrets[1].Key, "API_TOKEN")
 	}
-	if *secrets[1].EnvironmentVariable != "API_TOKEN" {
-		t.Errorf("secrets[1].EnvironmentVariable = %q, want %q", *secrets[1].EnvironmentVariable, "API_TOKEN")
+	if secrets[1].EnvironmentVariable != "API_TOKEN" {
+		t.Errorf("secrets[1].EnvironmentVariable = %q, want %q", secrets[1].EnvironmentVariable, "API_TOKEN")
 	}
 }
 
@@ -71,16 +72,16 @@ func TestSecretsUnmarshalYAML(t *testing.T) {
 	if secrets[0].Key != "DATABASE_URL" {
 		t.Errorf("secrets[0].Key = %q, want %q", secrets[0].Key, "DATABASE_URL")
 	}
-	if *secrets[0].EnvironmentVariable != "DATABASE_URL" {
-		t.Errorf("secrets[0].EnvironmentVariable = %q, want %q", *secrets[0].EnvironmentVariable, "DATABASE_URL")
+	if secrets[0].EnvironmentVariable != "DATABASE_URL" {
+		t.Errorf("secrets[0].EnvironmentVariable = %q, want %q", secrets[0].EnvironmentVariable, "DATABASE_URL")
 	}
 
 	// Check second secret
 	if secrets[1].Key != "API_TOKEN" {
 		t.Errorf("secrets[1].Key = %q, want %q", secrets[1].Key, "API_TOKEN")
 	}
-	if *secrets[1].EnvironmentVariable != "API_TOKEN" {
-		t.Errorf("secrets[1].EnvironmentVariable = %q, want %q", *secrets[1].EnvironmentVariable, "API_TOKEN")
+	if secrets[1].EnvironmentVariable != "API_TOKEN" {
+		t.Errorf("secrets[1].EnvironmentVariable = %q, want %q", secrets[1].EnvironmentVariable, "API_TOKEN")
 	}
 }
 
@@ -126,20 +127,14 @@ func TestSecretsUnmarshalNullYAML(t *testing.T) {
 func TestSecretsMergeWith(t *testing.T) {
 	t.Parallel()
 
-	// Test basic merging functionality
-	dbUrl := "DATABASE_URL"
-	redisUrl := "REDIS_URL"
-	apiToken := "API_TOKEN"
-	dbUrlOverride := "DATABASE_URL"
-
 	baseSecrets := Secrets{
-		&Secret{Key: "DB_KEY", EnvironmentVariable: &dbUrl},
-		&Secret{Key: "REDIS_KEY", EnvironmentVariable: &redisUrl},
+		Secret{Key: "DB_KEY", EnvironmentVariable: "DATABASE_URL"},
+		Secret{Key: "REDIS_KEY", EnvironmentVariable: "REDIS_URL"},
 	}
 
 	stepSecrets := Secrets{
-		&Secret{Key: "API_KEY", EnvironmentVariable: &apiToken},
-		&Secret{Key: "DB_OVERRIDE", EnvironmentVariable: &dbUrlOverride}, // Should override base
+		Secret{Key: "API_KEY", EnvironmentVariable: "API_TOKEN"},
+		Secret{Key: "DB_OVERRIDE", EnvironmentVariable: "DATABASE_URL"},
 	}
 
 	merged := baseSecrets.MergeWith(stepSecrets)
@@ -148,54 +143,44 @@ func TestSecretsMergeWith(t *testing.T) {
 		t.Fatalf("len(merged) = %d, want 3", len(merged))
 	}
 
-	// Step secrets should come first and take precedence
-	if merged[0].Key != "API_KEY" || *merged[0].EnvironmentVariable != "API_TOKEN" {
-		t.Errorf("merged[0] = Key:%q, EnvVar:%q, want Key:%q, EnvVar:%q",
-			merged[0].Key, *merged[0].EnvironmentVariable, "API_KEY", "API_TOKEN")
+	want := Secrets{
+		Secret{Key: "API_KEY", EnvironmentVariable: "API_TOKEN"},
+		Secret{Key: "DB_OVERRIDE", EnvironmentVariable: "DATABASE_URL"},
+		Secret{Key: "REDIS_KEY", EnvironmentVariable: "REDIS_URL"},
 	}
 
-	// DATABASE_URL should use step override, not base
-	if merged[1].Key != "DB_OVERRIDE" || *merged[1].EnvironmentVariable != "DATABASE_URL" {
-		t.Errorf("merged[1] = Key:%q, EnvVar:%q, want Key:%q, EnvVar:%q",
-			merged[1].Key, *merged[1].EnvironmentVariable, "DB_OVERRIDE", "DATABASE_URL")
-	}
-
-	// REDIS_URL should come from base (no override)
-	if merged[2].Key != "REDIS_KEY" || *merged[2].EnvironmentVariable != "REDIS_URL" {
-		t.Errorf("merged[2] = Key:%q, EnvVar:%q, want Key:%q, EnvVar:%q",
-			merged[2].Key, *merged[2].EnvironmentVariable, "REDIS_KEY", "REDIS_URL")
+	if diff := cmp.Diff(merged, want); diff != "" {
+		t.Errorf("merged mismatch (-got +want):\n%s", diff)
 	}
 }
 
 func TestSecretsMergeWithEmptySlices(t *testing.T) {
 	t.Parallel()
 
-	dbUrl := "DATABASE_URL"
 	baseSecrets := Secrets{
-		&Secret{Key: "DB_KEY", EnvironmentVariable: &dbUrl},
+		Secret{Key: "DB_KEY", EnvironmentVariable: "DATABASE_URL"},
 	}
 
-	// Empty other should return base
-	merged1 := baseSecrets.MergeWith(Secrets{})
-	if len(merged1) != 1 {
-		t.Fatalf("len(merged1) = %d, want 1", len(merged1))
+	want := Secrets{
+		Secret{Key: "DB_KEY", EnvironmentVariable: "DATABASE_URL"},
 	}
-	if merged1[0].Key != "DB_KEY" {
-		t.Errorf("merged1[0].Key = %q, want %q", merged1[0].Key, "DB_KEY")
+
+	merged1 := baseSecrets.MergeWith(Secrets{})
+
+	if diff := cmp.Diff(merged1, want); diff != "" {
+		t.Errorf("merged1 mismatch (-got +want):\n%s", diff)
 	}
 
 	// Empty base should return other
 	merged2 := Secrets{}.MergeWith(baseSecrets)
-	if len(merged2) != 1 {
-		t.Fatalf("len(merged2) = %d, want 1", len(merged2))
-	}
-	if merged2[0].Key != "DB_KEY" {
-		t.Errorf("merged2[0].Key = %q, want %q", merged2[0].Key, "DB_KEY")
+
+	if diff := cmp.Diff(merged2, want); diff != "" {
+		t.Errorf("merged2 mismatch (-got +want):\n%s", diff)
 	}
 
 	// Both empty should return empty
 	merged3 := Secrets{}.MergeWith(Secrets{})
-	if len(merged3) != 0 {
-		t.Fatalf("len(merged3) = %d, want 0", len(merged3))
+	if diff := cmp.Diff(merged3, Secrets{}); diff != "" {
+		t.Errorf("merged3 mismatch (-got +want):\n%s", diff)
 	}
 }

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -573,3 +573,53 @@ API_TOKEN: api-secret-key
 		t.Errorf("map format unmarshaling mismatch (-got +want):\n%s", diff)
 	}
 }
+
+func TestSecretsMarshalYAMLUnsupportedConfiguration(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		secrets Secrets
+	}{
+		{
+			name: "secret with RemainingFields",
+			secrets: Secrets{
+				Secret{
+					Key:                 "secret-key",
+					EnvironmentVariable: "ENV_VAR",
+					RemainingFields:     map[string]any{"custom": "field"},
+				},
+			},
+		},
+		{
+			name: "secret with empty EnvironmentVariable",
+			secrets: Secrets{
+				Secret{
+					Key:                 "secret-key",
+					EnvironmentVariable: "",
+				},
+			},
+		},
+		{
+			name: "mixed valid and invalid secrets",
+			secrets: Secrets{
+				Secret{Key: "valid-secret", EnvironmentVariable: "VALID_ENV"},
+				Secret{Key: "invalid-secret", EnvironmentVariable: ""},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.secrets.MarshalYAML()
+			if err == nil {
+				t.Fatalf("MarshalYAML() should return error for unsupported configuration, got nil")
+			}
+
+			expectedErr := "cannot marshal secrets to YAML: contains secrets with unsupported fields or empty environment variables"
+			if err.Error() != expectedErr {
+				t.Errorf("MarshalYAML() error = %q, want %q", err.Error(), expectedErr)
+			}
+		})
+	}
+}

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -455,50 +455,6 @@ func TestSecretsBackwardCompatibility(t *testing.T) {
 	}
 }
 
-func TestSecretsBackwardCompatibilityJSON(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name     string
-		jsonData string
-		want     Secrets
-	}{
-		{
-			name:     "simple array format",
-			jsonData: `["DATABASE_URL", "API_TOKEN"]`,
-			want: Secrets{
-				Secret{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
-				Secret{Key: "API_TOKEN", EnvironmentVariable: "API_TOKEN"},
-			},
-		},
-		{
-			name: "backend object format",
-			jsonData: `[
-				{"key": "database-secret", "environment_variable": "DATABASE_URL"},
-				{"key": "api-secret", "environment_variable": "API_TOKEN"}
-			]`,
-			want: Secrets{
-				Secret{Key: "database-secret", EnvironmentVariable: "DATABASE_URL"},
-				Secret{Key: "api-secret", EnvironmentVariable: "API_TOKEN"},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			var secrets Secrets
-			err := json.Unmarshal([]byte(tc.jsonData), &secrets)
-			if err != nil {
-				t.Fatalf("json.Unmarshal() error = %v", err)
-			}
-
-			if diff := cmp.Diff(secrets, tc.want); diff != "" {
-				t.Errorf("secrets mismatch (-got +want):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestSecretsInvalidFormatErrors(t *testing.T) {
 	t.Parallel()
 
@@ -560,7 +516,6 @@ func TestSecretsInvalidFormatErrors(t *testing.T) {
 	}
 }
 
-
 func TestSecretsMarshalYAMLMapSyntax(t *testing.T) {
 	t.Parallel()
 
@@ -586,5 +541,35 @@ func TestSecretsMarshalYAMLMapSyntax(t *testing.T) {
 
 	if diff := cmp.Diff(mapData, want); diff != "" {
 		t.Errorf("map format mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestSecretsUnmarshalMapFormat(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+ENV_VAR: secret-key
+API_TOKEN: api-secret-key
+`
+
+	var secrets Secrets
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(yamlData), &node)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err = ordered.Unmarshal(&node, &secrets)
+	if err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	want := Secrets{
+		Secret{Key: "secret-key", EnvironmentVariable: "ENV_VAR"},
+		Secret{Key: "api-secret-key", EnvironmentVariable: "API_TOKEN"},
+	}
+
+	if diff := cmp.Diff(secrets, want); diff != "" {
+		t.Errorf("map format unmarshaling mismatch (-got +want):\n%s", diff)
 	}
 }

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -375,6 +375,130 @@ THIRD: third-key
 	}
 }
 
+func TestSecretsBackwardCompatibility(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		yamlData string
+		want     Secrets
+	}{
+		{
+			name: "simple array format",
+			yamlData: `
+- DATABASE_URL
+- API_TOKEN
+- REDIS_URL
+`,
+			want: Secrets{
+				Secret{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
+				Secret{Key: "API_TOKEN", EnvironmentVariable: "API_TOKEN"},
+				Secret{Key: "REDIS_URL", EnvironmentVariable: "REDIS_URL"},
+			},
+		},
+		{
+			name: "backend object format",
+			yamlData: `
+- key: database-secret
+  environment_variable: DATABASE_URL
+- key: api-secret
+  environment_variable: API_TOKEN
+`,
+			want: Secrets{
+				Secret{Key: "database-secret", EnvironmentVariable: "DATABASE_URL"},
+				Secret{Key: "api-secret", EnvironmentVariable: "API_TOKEN"},
+			},
+		},
+		{
+			name: "backend object format with missing environment_variable",
+			yamlData: `
+- key: database-secret
+`,
+			want: Secrets{
+				Secret{Key: "database-secret", EnvironmentVariable: ""},
+			},
+		},
+		{
+			name: "mixed array formats",
+			yamlData: `
+- DATABASE_URL
+- key: api-secret
+  environment_variable: API_TOKEN
+- REDIS_URL
+`,
+			want: Secrets{
+				Secret{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
+				Secret{Key: "api-secret", EnvironmentVariable: "API_TOKEN"},
+				Secret{Key: "REDIS_URL", EnvironmentVariable: "REDIS_URL"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var secrets Secrets
+			var node yaml.Node
+			err := yaml.Unmarshal([]byte(tc.yamlData), &node)
+			if err != nil {
+				t.Fatalf("yaml.Unmarshal() error = %v", err)
+			}
+
+			err = ordered.Unmarshal(&node, &secrets)
+			if err != nil {
+				t.Fatalf("ordered.Unmarshal() error = %v", err)
+			}
+
+			if diff := cmp.Diff(secrets, tc.want); diff != "" {
+				t.Errorf("secrets mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSecretsBackwardCompatibilityJSON(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		jsonData string
+		want     Secrets
+	}{
+		{
+			name:     "simple array format",
+			jsonData: `["DATABASE_URL", "API_TOKEN"]`,
+			want: Secrets{
+				Secret{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
+				Secret{Key: "API_TOKEN", EnvironmentVariable: "API_TOKEN"},
+			},
+		},
+		{
+			name: "backend object format",
+			jsonData: `[
+				{"key": "database-secret", "environment_variable": "DATABASE_URL"},
+				{"key": "api-secret", "environment_variable": "API_TOKEN"}
+			]`,
+			want: Secrets{
+				Secret{Key: "database-secret", EnvironmentVariable: "DATABASE_URL"},
+				Secret{Key: "api-secret", EnvironmentVariable: "API_TOKEN"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var secrets Secrets
+			err := json.Unmarshal([]byte(tc.jsonData), &secrets)
+			if err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+
+			if diff := cmp.Diff(secrets, tc.want); diff != "" {
+				t.Errorf("secrets mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestSecretsInvalidFormatErrors(t *testing.T) {
 	t.Parallel()
 
@@ -433,5 +557,34 @@ func TestSecretsInvalidFormatErrors(t *testing.T) {
 				t.Errorf("ordered.Unmarshal() error = %q, want %q", err.Error(), tc.expectedErr)
 			}
 		})
+	}
+}
+
+
+func TestSecretsMarshalYAMLMapSyntax(t *testing.T) {
+	t.Parallel()
+
+	secrets := Secrets{
+		Secret{Key: "database-secret-key", EnvironmentVariable: "DATABASE_URL"},
+		Secret{Key: "api-secret-key", EnvironmentVariable: "API_TOKEN"},
+	}
+
+	yamlData, err := secrets.MarshalYAML()
+	if err != nil {
+		t.Fatalf("MarshalYAML() error = %v", err)
+	}
+
+	mapData, ok := yamlData.(map[string]string)
+	if !ok {
+		t.Fatalf("MarshalYAML() returned %T, want map[string]string", yamlData)
+	}
+
+	want := map[string]string{
+		"DATABASE_URL": "database-secret-key",
+		"API_TOKEN":    "api-secret-key",
+	}
+
+	if diff := cmp.Diff(mapData, want); diff != "" {
+		t.Errorf("map format mismatch (-got +want):\n%s", diff)
 	}
 }

--- a/signature/pipeline_invariants.go
+++ b/signature/pipeline_invariants.go
@@ -37,6 +37,11 @@ func (c *commandStepWithInvariants) SignedFields() (map[string]any, error) {
 		"repository_url": c.RepositoryURL,
 	}
 
+	// Only include secrets if non-empty to maintain backward compatibility
+	if len(c.Secrets) > 0 {
+		object["secrets"] = EmptyToNilSlice(c.Secrets)
+	}
+
 	// Step env overrides pipeline and build env:
 	// https://buildkite.com/docs/tutorials/pipeline-upgrade#what-is-the-yaml-steps-editor-compatibility-issues
 	// (Beware of inconsistent docs written in the time of legacy steps.)
@@ -64,6 +69,11 @@ func (c *commandStepWithInvariants) ValuesForFields(fields []string) (map[string
 		"repository_url": {},
 	}
 
+	// Only require secrets field if step has secrets
+	if len(c.Secrets) > 0 {
+		required["secrets"] = struct{}{}
+	}
+
 	out := make(map[string]any, len(fields))
 	for _, f := range fields {
 		delete(required, f)
@@ -83,6 +93,9 @@ func (c *commandStepWithInvariants) ValuesForFields(fields []string) (map[string
 
 		case "repository_url":
 			out["repository_url"] = c.RepositoryURL
+
+		case "secrets":
+			out["secrets"] = EmptyToNilSlice(c.Secrets)
 
 		default:
 			if name, has := strings.CutPrefix(f, EnvNamespacePrefix); has {

--- a/signature/pipeline_invariants_test.go
+++ b/signature/pipeline_invariants_test.go
@@ -71,7 +71,7 @@ func TestCommandStepWithInvariants_ValuesForFields_WithSecrets(t *testing.T) {
 			Env:     map[string]string{"FOO": "bar"},
 			Plugins: pipeline.Plugins{},
 			Secrets: pipeline.Secrets{
-				{Key: "DATABASE_URL", EnvironmentVariable: &dbUrl},
+				{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
 			},
 		},
 		RepositoryURL: "https://github.com/example/repo",
@@ -150,8 +150,8 @@ func TestCommandStepWithInvariants_ValuesForFields_NoSecretsNoSecretsField(t *te
 	wantValues := map[string]any{
 		"command":        "echo hello",
 		"env":            map[string]string{"FOO": "bar"},
-		"plugins":        nil,
-		"matrix":         nil,
+		"plugins":        pipeline.Plugins(nil),
+		"matrix":         (*pipeline.Matrix)(nil),
 		"repository_url": "https://github.com/example/repo",
 	}
 

--- a/signature/pipeline_invariants_test.go
+++ b/signature/pipeline_invariants_test.go
@@ -10,14 +10,13 @@ import (
 func TestCommandStepWithInvariants_SignedFields_WithSecrets(t *testing.T) {
 	t.Parallel()
 
-	dbUrl := "DATABASE_URL"
 	step := commandStepWithInvariants{
 		CommandStep: pipeline.CommandStep{
 			Command: "echo hello",
 			Env:     map[string]string{"FOO": "bar"},
 			Plugins: pipeline.Plugins{},
 			Secrets: pipeline.Secrets{
-				{Key: "DATABASE_URL", EnvironmentVariable: &dbUrl},
+				{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
 			},
 		},
 		RepositoryURL: "https://github.com/example/repo",
@@ -30,7 +29,7 @@ func TestCommandStepWithInvariants_SignedFields_WithSecrets(t *testing.T) {
 	}
 
 	want := pipeline.Secrets{
-		{Key: "DATABASE_URL", EnvironmentVariable: &dbUrl},
+		{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
 	}
 
 	if diff := cmp.Diff(fields["secrets"], want); diff != "" {
@@ -66,7 +65,6 @@ func TestCommandStepWithInvariants_SignedFields_EmptySecrets(t *testing.T) {
 func TestCommandStepWithInvariants_ValuesForFields_WithSecrets(t *testing.T) {
 	t.Parallel()
 
-	dbUrl := "DATABASE_URL"
 	step := commandStepWithInvariants{
 		CommandStep: pipeline.CommandStep{
 			Command: "echo hello",
@@ -87,7 +85,7 @@ func TestCommandStepWithInvariants_ValuesForFields_WithSecrets(t *testing.T) {
 	}
 
 	want := pipeline.Secrets{
-		{Key: "DATABASE_URL", EnvironmentVariable: &dbUrl},
+		{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
 	}
 
 	if _, has := values["secrets"]; !has {
@@ -102,14 +100,13 @@ func TestCommandStepWithInvariants_ValuesForFields_WithSecrets(t *testing.T) {
 func TestCommandStepWithInvariants_ValuesForFields_MissingSecretsField(t *testing.T) {
 	t.Parallel()
 
-	dbUrl := "DATABASE_URL"
 	step := commandStepWithInvariants{
 		CommandStep: pipeline.CommandStep{
 			Command: "echo hello",
 			Env:     map[string]string{"FOO": "bar"},
 			Plugins: pipeline.Plugins{},
 			Secrets: pipeline.Secrets{
-				{Key: "DATABASE_URL", EnvironmentVariable: &dbUrl},
+				{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
 			},
 		},
 		RepositoryURL: "https://github.com/example/repo",

--- a/signature/pipeline_invariants_test.go
+++ b/signature/pipeline_invariants_test.go
@@ -1,0 +1,179 @@
+package signature
+
+import (
+	"testing"
+
+	"github.com/buildkite/go-pipeline"
+)
+
+func TestCommandStepWithInvariants_SignedFields_WithSecrets(t *testing.T) {
+	t.Parallel()
+
+	dbUrl := "DATABASE_URL"
+	step := commandStepWithInvariants{
+		CommandStep: pipeline.CommandStep{
+			Command: "echo hello",
+			Env:     map[string]string{"FOO": "bar"},
+			Plugins: pipeline.Plugins{},
+			Secrets: pipeline.Secrets{
+				{Key: "DATABASE_URL", EnvironmentVariable: &dbUrl},
+			},
+		},
+		RepositoryURL: "https://github.com/example/repo",
+		OuterEnv:      map[string]string{"PIPELINE_VAR": "value"},
+	}
+
+	fields, err := step.SignedFields()
+	if err != nil {
+		t.Fatalf("SignedFields() error = %v", err)
+	}
+
+	// Check that secrets field is included
+	if _, has := fields["secrets"]; !has {
+		t.Errorf("SignedFields() missing 'secrets' field")
+	}
+
+	// Check that secrets field contains expected data
+	secrets, ok := fields["secrets"].(pipeline.Secrets)
+	if !ok {
+		t.Errorf("SignedFields() 'secrets' field is not pipeline.Secrets type, got %T", fields["secrets"])
+	}
+
+	if len(secrets) != 1 {
+		t.Errorf("SignedFields() expected 1 secret, got %d", len(secrets))
+	}
+
+	if secrets[0].Key != "DATABASE_URL" {
+		t.Errorf("SignedFields() expected secret key 'DATABASE_URL', got %q", secrets[0].Key)
+	}
+}
+
+func TestCommandStepWithInvariants_SignedFields_EmptySecrets(t *testing.T) {
+	t.Parallel()
+
+	step := commandStepWithInvariants{
+		CommandStep: pipeline.CommandStep{
+			Command: "echo hello",
+			Env:     map[string]string{"FOO": "bar"},
+			Plugins: nil, // nil plugins - this should become nil
+			Secrets: nil, // nil secrets - this should become nil
+		},
+		RepositoryURL: "https://github.com/example/repo",
+		OuterEnv:      map[string]string{"PIPELINE_VAR": "value"},
+	}
+
+	fields, err := step.SignedFields()
+	if err != nil {
+		t.Fatalf("SignedFields() error = %v", err)
+	}
+
+	// Check that secrets field is NOT present when empty (for backward compatibility)
+	if _, has := fields["secrets"]; has {
+		t.Errorf("SignedFields() should not include 'secrets' field when empty for backward compatibility")
+	}
+}
+
+func TestCommandStepWithInvariants_ValuesForFields_WithSecrets(t *testing.T) {
+	t.Parallel()
+
+	dbUrl := "DATABASE_URL"
+	step := commandStepWithInvariants{
+		CommandStep: pipeline.CommandStep{
+			Command: "echo hello",
+			Env:     map[string]string{"FOO": "bar"},
+			Plugins: pipeline.Plugins{},
+			Secrets: pipeline.Secrets{
+				{Key: "DATABASE_URL", EnvironmentVariable: &dbUrl},
+			},
+		},
+		RepositoryURL: "https://github.com/example/repo",
+		OuterEnv:      map[string]string{"PIPELINE_VAR": "value"},
+	}
+
+	fields := []string{"command", "env", "plugins", "matrix", "repository_url", "secrets"}
+	values, err := step.ValuesForFields(fields)
+	if err != nil {
+		t.Fatalf("ValuesForFields() error = %v", err)
+	}
+
+	// Check that secrets value is included
+	if _, has := values["secrets"]; !has {
+		t.Errorf("ValuesForFields() missing 'secrets' field")
+	}
+
+	// Check that secrets field contains expected data
+	secrets, ok := values["secrets"].(pipeline.Secrets)
+	if !ok {
+		t.Errorf("ValuesForFields() 'secrets' field is not pipeline.Secrets type, got %T", values["secrets"])
+	}
+
+	if len(secrets) != 1 {
+		t.Errorf("ValuesForFields() expected 1 secret, got %d", len(secrets))
+	}
+
+	if secrets[0].Key != "DATABASE_URL" {
+		t.Errorf("ValuesForFields() expected secret key 'DATABASE_URL', got %q", secrets[0].Key)
+	}
+}
+
+func TestCommandStepWithInvariants_ValuesForFields_MissingSecretsField(t *testing.T) {
+	t.Parallel()
+
+	dbUrl := "DATABASE_URL"
+	step := commandStepWithInvariants{
+		CommandStep: pipeline.CommandStep{
+			Command: "echo hello",
+			Env:     map[string]string{"FOO": "bar"},
+			Plugins: pipeline.Plugins{},
+			Secrets: pipeline.Secrets{
+				{Key: "DATABASE_URL", EnvironmentVariable: &dbUrl},
+			},
+		},
+		RepositoryURL: "https://github.com/example/repo",
+		OuterEnv:      map[string]string{"PIPELINE_VAR": "value"},
+	}
+
+	// Request fields without secrets - should fail
+	fields := []string{"command", "env", "plugins", "matrix", "repository_url"}
+	_, err := step.ValuesForFields(fields)
+	if err == nil {
+		t.Fatalf("ValuesForFields() expected error when secrets field not requested but step has secrets")
+	}
+
+	expectedError := "one or more required fields are not present: [secrets]"
+	if err.Error() != expectedError {
+		t.Errorf("ValuesForFields() expected error %q, got %q", expectedError, err.Error())
+	}
+}
+
+func TestCommandStepWithInvariants_ValuesForFields_NoSecretsNoSecretsField(t *testing.T) {
+	t.Parallel()
+
+	step := commandStepWithInvariants{
+		CommandStep: pipeline.CommandStep{
+			Command: "echo hello",
+			Env:     map[string]string{"FOO": "bar"},
+			Plugins: pipeline.Plugins{},
+			Secrets: nil, // No secrets
+		},
+		RepositoryURL: "https://github.com/example/repo",
+		OuterEnv:      map[string]string{"PIPELINE_VAR": "value"},
+	}
+
+	// Request fields without secrets - should succeed when step has no secrets
+	fields := []string{"command", "env", "plugins", "matrix", "repository_url"}
+	values, err := step.ValuesForFields(fields)
+	if err != nil {
+		t.Fatalf("ValuesForFields() unexpected error when step has no secrets and secrets field not requested: %v", err)
+	}
+
+	// Should have all the requested fields
+	if len(values) != 5 {
+		t.Errorf("ValuesForFields() returned %d fields, want 5", len(values))
+	}
+
+	// Should not have secrets field
+	if _, has := values["secrets"]; has {
+		t.Errorf("ValuesForFields() should not include 'secrets' field when step has no secrets")
+	}
+}

--- a/signature/pipeline_invariants_test.go
+++ b/signature/pipeline_invariants_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/go-pipeline"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestCommandStepWithInvariants_SignedFields_WithSecrets(t *testing.T) {
@@ -25,26 +26,15 @@ func TestCommandStepWithInvariants_SignedFields_WithSecrets(t *testing.T) {
 
 	fields, err := step.SignedFields()
 	if err != nil {
-		t.Fatalf("SignedFields() error = %v", err)
+		t.Fatalf("step.SignedFields() error = %v", err)
 	}
 
-	// Check that secrets field is included
-	if _, has := fields["secrets"]; !has {
-		t.Errorf("SignedFields() missing 'secrets' field")
+	want := pipeline.Secrets{
+		{Key: "DATABASE_URL", EnvironmentVariable: &dbUrl},
 	}
 
-	// Check that secrets field contains expected data
-	secrets, ok := fields["secrets"].(pipeline.Secrets)
-	if !ok {
-		t.Errorf("SignedFields() 'secrets' field is not pipeline.Secrets type, got %T", fields["secrets"])
-	}
-
-	if len(secrets) != 1 {
-		t.Errorf("SignedFields() expected 1 secret, got %d", len(secrets))
-	}
-
-	if secrets[0].Key != "DATABASE_URL" {
-		t.Errorf("SignedFields() expected secret key 'DATABASE_URL', got %q", secrets[0].Key)
+	if diff := cmp.Diff(fields["secrets"], want); diff != "" {
+		t.Errorf("step.SignedFields()[\"secrets\"] diff (-got +want):\n%s", diff)
 	}
 }
 
@@ -55,8 +45,8 @@ func TestCommandStepWithInvariants_SignedFields_EmptySecrets(t *testing.T) {
 		CommandStep: pipeline.CommandStep{
 			Command: "echo hello",
 			Env:     map[string]string{"FOO": "bar"},
-			Plugins: nil, // nil plugins - this should become nil
-			Secrets: nil, // nil secrets - this should become nil
+			Plugins: nil,
+			Secrets: nil,
 		},
 		RepositoryURL: "https://github.com/example/repo",
 		OuterEnv:      map[string]string{"PIPELINE_VAR": "value"},
@@ -64,12 +54,12 @@ func TestCommandStepWithInvariants_SignedFields_EmptySecrets(t *testing.T) {
 
 	fields, err := step.SignedFields()
 	if err != nil {
-		t.Fatalf("SignedFields() error = %v", err)
+		t.Fatalf("step.SignedFields() error = %v", err)
 	}
 
 	// Check that secrets field is NOT present when empty (for backward compatibility)
 	if _, has := fields["secrets"]; has {
-		t.Errorf("SignedFields() should not include 'secrets' field when empty for backward compatibility")
+		t.Errorf("step.SignedFields()[\"secrets\"] = %v, want: nil", fields["secrets"])
 	}
 }
 
@@ -93,26 +83,19 @@ func TestCommandStepWithInvariants_ValuesForFields_WithSecrets(t *testing.T) {
 	fields := []string{"command", "env", "plugins", "matrix", "repository_url", "secrets"}
 	values, err := step.ValuesForFields(fields)
 	if err != nil {
-		t.Fatalf("ValuesForFields() error = %v", err)
+		t.Fatalf("step.ValuesForFields() error = %v", err)
 	}
 
-	// Check that secrets value is included
+	want := pipeline.Secrets{
+		{Key: "DATABASE_URL", EnvironmentVariable: &dbUrl},
+	}
+
 	if _, has := values["secrets"]; !has {
-		t.Errorf("ValuesForFields() missing 'secrets' field")
+		t.Errorf("step.ValuesForFields() missing 'secrets' field, got: %v, want: %v", values["secrets"], want)
 	}
 
-	// Check that secrets field contains expected data
-	secrets, ok := values["secrets"].(pipeline.Secrets)
-	if !ok {
-		t.Errorf("ValuesForFields() 'secrets' field is not pipeline.Secrets type, got %T", values["secrets"])
-	}
-
-	if len(secrets) != 1 {
-		t.Errorf("ValuesForFields() expected 1 secret, got %d", len(secrets))
-	}
-
-	if secrets[0].Key != "DATABASE_URL" {
-		t.Errorf("ValuesForFields() expected secret key 'DATABASE_URL', got %q", secrets[0].Key)
+	if diff := cmp.Diff(values["secrets"], want); diff != "" {
+		t.Errorf("step.ValuesForFields(%v)[\"secrets\"] diff (-got +want):\n%s", fields, diff)
 	}
 }
 
@@ -137,12 +120,12 @@ func TestCommandStepWithInvariants_ValuesForFields_MissingSecretsField(t *testin
 	fields := []string{"command", "env", "plugins", "matrix", "repository_url"}
 	_, err := step.ValuesForFields(fields)
 	if err == nil {
-		t.Fatalf("ValuesForFields() expected error when secrets field not requested but step has secrets")
+		t.Fatalf("step.ValuesForFields(%v) expected error when secrets field not requested but step has secrets", fields)
 	}
 
-	expectedError := "one or more required fields are not present: [secrets]"
-	if err.Error() != expectedError {
-		t.Errorf("ValuesForFields() expected error %q, got %q", expectedError, err.Error())
+	wantErr := "one or more required fields are not present: [secrets]"
+	if err.Error() != wantErr {
+		t.Errorf("step.ValuesForFields(%v) = %q, want %q", fields, err.Error(), wantErr)
 	}
 }
 
@@ -164,16 +147,18 @@ func TestCommandStepWithInvariants_ValuesForFields_NoSecretsNoSecretsField(t *te
 	fields := []string{"command", "env", "plugins", "matrix", "repository_url"}
 	values, err := step.ValuesForFields(fields)
 	if err != nil {
-		t.Fatalf("ValuesForFields() unexpected error when step has no secrets and secrets field not requested: %v", err)
+		t.Fatalf("step.ValuesForFields(%v) unexpected error when step has no secrets and secrets field not requested: %v", fields, err)
 	}
 
-	// Should have all the requested fields
-	if len(values) != 5 {
-		t.Errorf("ValuesForFields() returned %d fields, want 5", len(values))
+	wantValues := map[string]any{
+		"command":        "echo hello",
+		"env":            map[string]string{"FOO": "bar"},
+		"plugins":        nil,
+		"matrix":         nil,
+		"repository_url": "https://github.com/example/repo",
 	}
 
-	// Should not have secrets field
-	if _, has := values["secrets"]; has {
-		t.Errorf("ValuesForFields() should not include 'secrets' field when step has no secrets")
+	if diff := cmp.Diff(values, wantValues); diff != "" {
+		t.Errorf("step.ValuesForFields(%v) diff (-got +want):\n%s", fields, diff)
 	}
 }

--- a/signature/sign_test.go
+++ b/signature/sign_test.go
@@ -429,6 +429,89 @@ func TestSignUnknownStep(t *testing.T) {
 	}
 }
 
+func TestSignVerifySecrets(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cases := []struct {
+		name            string
+		step            *pipeline.CommandStep
+		repositoryURL   string
+		pipelineSecrets pipeline.Secrets
+	}{
+		{
+			name: "step secrets only",
+			step: &pipeline.CommandStep{
+				Command: "llamas",
+				Secrets: pipeline.Secrets{
+					pipeline.Secret{Key: "SECRET_NAME", EnvironmentVariable: "SECRET_ENV_VAR"},
+				},
+			},
+			repositoryURL:   fakeRepositoryURL,
+			pipelineSecrets: pipeline.Secrets{},
+		},
+		{
+			name: "pipeline and step secrets",
+			step: &pipeline.CommandStep{
+				Command: "llamas",
+				Secrets: pipeline.Secrets{
+					pipeline.Secret{Key: "SECRET_NAME", EnvironmentVariable: "SECRET_ENV_VAR"},
+				},
+			},
+			repositoryURL: fakeRepositoryURL,
+			pipelineSecrets: pipeline.Secrets{
+				pipeline.Secret{Key: "SECRET_NAME", EnvironmentVariable: "SECRET_ENV_VAR"},
+			},
+		},
+		{
+			name: "pipeline only",
+			step: &pipeline.CommandStep{
+				Command: "llamas",
+				Secrets: pipeline.Secrets{},
+			},
+			repositoryURL: fakeRepositoryURL,
+			pipelineSecrets: pipeline.Secrets{
+				pipeline.Secret{Key: "SECRET_NAME", EnvironmentVariable: "SECRET_ENV_VAR"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			keyStr, keyAlg := "alpacas", jwa.HS256
+			signer, verifier, err := jwkutil.NewSymmetricKeyPairFromString(keyID, keyStr, keyAlg)
+			if err != nil {
+				t.Fatalf("jwkutil.NewSymmetricKeyPairFromString(%q, %q, %q) error = %v", keyID, keyStr, keyAlg, err)
+			}
+
+			key, ok := signer.Key(0)
+			if !ok {
+				t.Fatalf("signer.Key(0) = _, false, want true")
+			}
+
+			stepToSign := &commandStepWithInvariants{
+				CommandStep:   *tc.step,
+				RepositoryURL: tc.repositoryURL,
+			}
+			stepToVerify := &commandStepWithInvariants{
+				CommandStep:   *tc.step,
+				RepositoryURL: tc.repositoryURL,
+			}
+
+			sig, err := Sign(ctx, key, stepToSign)
+			if err != nil {
+				t.Fatalf("Sign(ctx, key, %v) error = %v", stepToSign, err)
+			}
+
+			if err := Verify(ctx, sig, verifier, stepToVerify); err != nil {
+				t.Errorf("Verify(ctx, %v, verifier, %v) = %v", sig, stepToVerify, err)
+			}
+		})
+	}
+}
+
 func TestSignVerifyEnv(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/step_command_secrets_test.go
+++ b/step_command_secrets_test.go
@@ -1,0 +1,183 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/buildkite/go-pipeline/ordered"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCommandStepSecretsStringArrayFormat(t *testing.T) {
+	t.Parallel()
+
+	// Test string array format
+	yamlData := `
+- command: echo "Array format"
+  secrets:
+    - DATABASE_URL
+    - API_TOKEN
+
+- command: echo "Another step"
+  secrets:
+    - SSH_KEY
+    - REDIS_URL
+`
+
+	var steps []CommandStep
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(yamlData), &node)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err = ordered.Unmarshal(&node, &steps)
+	if err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	if len(steps) != 2 {
+		t.Fatalf("len(steps) = %d, want 2", len(steps))
+	}
+
+	// Check step 1
+	if len(steps[0].Secrets) != 2 {
+		t.Fatalf("len(steps[0].Secrets) = %d, want 2", len(steps[0].Secrets))
+	}
+	if steps[0].Secrets[0].Key != "DATABASE_URL" {
+		t.Errorf("steps[0].Secrets[0].Key = %q, want %q", steps[0].Secrets[0].Key, "DATABASE_URL")
+	}
+	if *steps[0].Secrets[0].EnvironmentVariable != "DATABASE_URL" {
+		t.Errorf("steps[0].Secrets[0].EnvironmentVariable = %q, want %q", *steps[0].Secrets[0].EnvironmentVariable, "DATABASE_URL")
+	}
+
+	// Check step 2
+	if len(steps[1].Secrets) != 2 {
+		t.Fatalf("len(steps[1].Secrets) = %d, want 2", len(steps[1].Secrets))
+	}
+	if steps[1].Secrets[0].Key != "SSH_KEY" {
+		t.Errorf("steps[1].Secrets[0].Key = %q, want %q", steps[1].Secrets[0].Key, "SSH_KEY")
+	}
+	if *steps[1].Secrets[0].EnvironmentVariable != "SSH_KEY" {
+		t.Errorf("steps[1].Secrets[0].EnvironmentVariable = %q, want %q", *steps[1].Secrets[0].EnvironmentVariable, "SSH_KEY")
+	}
+}
+
+func TestCommandStepSecretsNullError(t *testing.T) {
+	t.Parallel()
+
+	// Test that `secrets: null` in a command step returns an error
+	yamlData := `
+command: echo "hello"
+secrets: null
+`
+
+	var step CommandStep
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(yamlData), &node)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err = ordered.Unmarshal(&node, &step)
+	if err == nil {
+		t.Fatalf("ordered.Unmarshal() should return error for null secrets, got nil")
+	}
+
+	expectedErr := "unmarshalling CommandStep: unmarshaling secrets: secrets cannot be null"
+	if err.Error() != expectedErr {
+		t.Errorf("ordered.Unmarshal() error = %q, want %q", err.Error(), expectedErr)
+	}
+}
+
+func TestCommandStepMergeSecretsFromPipeline(t *testing.T) {
+	t.Parallel()
+
+	// Test merging pipeline secrets with step secrets
+	apiToken := "API_TOKEN"
+	dbUrl := "DATABASE_URL"
+	redisUrl := "REDIS_URL"
+
+	step := &CommandStep{
+		Command: "echo hello",
+		Secrets: Secrets{
+			&Secret{Key: "API_KEY", EnvironmentVariable: &apiToken},
+			&Secret{Key: "DB_OVERRIDE", EnvironmentVariable: &dbUrl}, // Should override pipeline
+		},
+	}
+
+	pipelineSecrets := Secrets{
+		&Secret{Key: "DB_KEY", EnvironmentVariable: &dbUrl},       // Will be overridden
+		&Secret{Key: "REDIS_KEY", EnvironmentVariable: &redisUrl}, // Will be added
+	}
+
+	step.MergeSecretsFromPipeline(pipelineSecrets)
+
+	if len(step.Secrets) != 3 {
+		t.Fatalf("len(step.Secrets) = %d, want 3", len(step.Secrets))
+	}
+
+	// Step secrets should come first and take precedence
+	if step.Secrets[0].Key != "API_KEY" || *step.Secrets[0].EnvironmentVariable != "API_TOKEN" {
+		t.Errorf("step.Secrets[0] = Key:%q, EnvVar:%q, want Key:%q, EnvVar:%q",
+			step.Secrets[0].Key, *step.Secrets[0].EnvironmentVariable, "API_KEY", "API_TOKEN")
+	}
+
+	// DATABASE_URL should use step override
+	if step.Secrets[1].Key != "DB_OVERRIDE" || *step.Secrets[1].EnvironmentVariable != "DATABASE_URL" {
+		t.Errorf("step.Secrets[1] = Key:%q, EnvVar:%q, want Key:%q, EnvVar:%q",
+			step.Secrets[1].Key, *step.Secrets[1].EnvironmentVariable, "DB_OVERRIDE", "DATABASE_URL")
+	}
+
+	// REDIS_URL should come from pipeline
+	if step.Secrets[2].Key != "REDIS_KEY" || *step.Secrets[2].EnvironmentVariable != "REDIS_URL" {
+		t.Errorf("step.Secrets[2] = Key:%q, EnvVar:%q, want Key:%q, EnvVar:%q",
+			step.Secrets[2].Key, *step.Secrets[2].EnvironmentVariable, "REDIS_KEY", "REDIS_URL")
+	}
+}
+
+func TestCommandStepWithSecrets(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+command: "echo hello"
+secrets:
+  - DATABASE_URL
+  - API_TOKEN
+`
+
+	var step CommandStep
+	var node yaml.Node
+	err := yaml.Unmarshal([]byte(yamlData), &node)
+	if err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err = ordered.Unmarshal(&node, &step)
+	if err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	if step.Command != "echo hello" {
+		t.Errorf("step.Command = %q, want %q", step.Command, "echo hello")
+	}
+
+	if len(step.Secrets) != 2 {
+		t.Fatalf("len(step.Secrets) = %d, want 2", len(step.Secrets))
+	}
+
+	// Check first secret
+	if step.Secrets[0].Key != "DATABASE_URL" {
+		t.Errorf("step.Secrets[0].Key = %q, want %q", step.Secrets[0].Key, "DATABASE_URL")
+	}
+	if *step.Secrets[0].EnvironmentVariable != "DATABASE_URL" {
+		t.Errorf("step.Secrets[0].EnvironmentVariable = %q, want %q", *step.Secrets[0].EnvironmentVariable, "DATABASE_URL")
+	}
+
+	// Check second secret
+	if step.Secrets[1].Key != "API_TOKEN" {
+		t.Errorf("step.Secrets[1].Key = %q, want %q", step.Secrets[1].Key, "API_TOKEN")
+	}
+	if *step.Secrets[1].EnvironmentVariable != "API_TOKEN" {
+		t.Errorf("step.Secrets[1].EnvironmentVariable = %q, want %q", *step.Secrets[1].EnvironmentVariable, "API_TOKEN")
+	}
+}

--- a/step_command_secrets_test.go
+++ b/step_command_secrets_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/buildkite/go-pipeline/ordered"
+	"github.com/google/go-cmp/cmp"
 	"gopkg.in/yaml.v3"
 )
 
@@ -39,26 +40,27 @@ func TestCommandStepSecretsStringArrayFormat(t *testing.T) {
 		t.Fatalf("len(steps) = %d, want 2", len(steps))
 	}
 
-	// Check step 1
-	if len(steps[0].Secrets) != 2 {
-		t.Fatalf("len(steps[0].Secrets) = %d, want 2", len(steps[0].Secrets))
-	}
-	if steps[0].Secrets[0].Key != "DATABASE_URL" {
-		t.Errorf("steps[0].Secrets[0].Key = %q, want %q", steps[0].Secrets[0].Key, "DATABASE_URL")
-	}
-	if *steps[0].Secrets[0].EnvironmentVariable != "DATABASE_URL" {
-		t.Errorf("steps[0].Secrets[0].EnvironmentVariable = %q, want %q", *steps[0].Secrets[0].EnvironmentVariable, "DATABASE_URL")
+	databaseURL := "DATABASE_URL"
+	apiToken := "API_TOKEN"
+	sshKey := "SSH_KEY"
+	redisURL := "REDIS_URL"
+
+	want := Secrets{
+		&Secret{Key: "DATABASE_URL", EnvironmentVariable: &databaseURL},
+		&Secret{Key: "API_TOKEN", EnvironmentVariable: &apiToken},
 	}
 
-	// Check step 2
-	if len(steps[1].Secrets) != 2 {
-		t.Fatalf("len(steps[1].Secrets) = %d, want 2", len(steps[1].Secrets))
+	if diff := cmp.Diff(steps[0].Secrets, want); diff != "" {
+		t.Errorf("steps[0].Secrets mismatch (-want +got):\n%s", diff)
 	}
-	if steps[1].Secrets[0].Key != "SSH_KEY" {
-		t.Errorf("steps[1].Secrets[0].Key = %q, want %q", steps[1].Secrets[0].Key, "SSH_KEY")
+
+	want = Secrets{
+		&Secret{Key: "SSH_KEY", EnvironmentVariable: &sshKey},
+		&Secret{Key: "REDIS_URL", EnvironmentVariable: &redisURL},
 	}
-	if *steps[1].Secrets[0].EnvironmentVariable != "SSH_KEY" {
-		t.Errorf("steps[1].Secrets[0].EnvironmentVariable = %q, want %q", *steps[1].Secrets[0].EnvironmentVariable, "SSH_KEY")
+
+	if diff := cmp.Diff(steps[1].Secrets, want); diff != "" {
+		t.Errorf("steps[1].Secrets mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -116,22 +118,14 @@ func TestCommandStepMergeSecretsFromPipeline(t *testing.T) {
 		t.Fatalf("len(step.Secrets) = %d, want 3", len(step.Secrets))
 	}
 
-	// Step secrets should come first and take precedence
-	if step.Secrets[0].Key != "API_KEY" || *step.Secrets[0].EnvironmentVariable != "API_TOKEN" {
-		t.Errorf("step.Secrets[0] = Key:%q, EnvVar:%q, want Key:%q, EnvVar:%q",
-			step.Secrets[0].Key, *step.Secrets[0].EnvironmentVariable, "API_KEY", "API_TOKEN")
+	want := Secrets{
+		&Secret{Key: "API_KEY", EnvironmentVariable: &apiToken},
+		&Secret{Key: "DB_OVERRIDE", EnvironmentVariable: &dbUrl},
+		&Secret{Key: "REDIS_KEY", EnvironmentVariable: &redisUrl},
 	}
 
-	// DATABASE_URL should use step override
-	if step.Secrets[1].Key != "DB_OVERRIDE" || *step.Secrets[1].EnvironmentVariable != "DATABASE_URL" {
-		t.Errorf("step.Secrets[1] = Key:%q, EnvVar:%q, want Key:%q, EnvVar:%q",
-			step.Secrets[1].Key, *step.Secrets[1].EnvironmentVariable, "DB_OVERRIDE", "DATABASE_URL")
-	}
-
-	// REDIS_URL should come from pipeline
-	if step.Secrets[2].Key != "REDIS_KEY" || *step.Secrets[2].EnvironmentVariable != "REDIS_URL" {
-		t.Errorf("step.Secrets[2] = Key:%q, EnvVar:%q, want Key:%q, EnvVar:%q",
-			step.Secrets[2].Key, *step.Secrets[2].EnvironmentVariable, "REDIS_KEY", "REDIS_URL")
+	if diff := cmp.Diff(step.Secrets, want); diff != "" {
+		t.Errorf("step.Secrets mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -144,6 +138,8 @@ secrets:
   - DATABASE_URL
   - API_TOKEN
 `
+	apiToken := "API_TOKEN"
+	dbUrl := "DATABASE_URL"
 
 	var step CommandStep
 	var node yaml.Node
@@ -161,23 +157,12 @@ secrets:
 		t.Errorf("step.Command = %q, want %q", step.Command, "echo hello")
 	}
 
-	if len(step.Secrets) != 2 {
-		t.Fatalf("len(step.Secrets) = %d, want 2", len(step.Secrets))
+	want := Secrets{
+		&Secret{Key: "DATABASE_URL", EnvironmentVariable: &dbUrl},
+		&Secret{Key: "API_TOKEN", EnvironmentVariable: &apiToken},
 	}
 
-	// Check first secret
-	if step.Secrets[0].Key != "DATABASE_URL" {
-		t.Errorf("step.Secrets[0].Key = %q, want %q", step.Secrets[0].Key, "DATABASE_URL")
-	}
-	if *step.Secrets[0].EnvironmentVariable != "DATABASE_URL" {
-		t.Errorf("step.Secrets[0].EnvironmentVariable = %q, want %q", *step.Secrets[0].EnvironmentVariable, "DATABASE_URL")
-	}
-
-	// Check second secret
-	if step.Secrets[1].Key != "API_TOKEN" {
-		t.Errorf("step.Secrets[1].Key = %q, want %q", step.Secrets[1].Key, "API_TOKEN")
-	}
-	if *step.Secrets[1].EnvironmentVariable != "API_TOKEN" {
-		t.Errorf("step.Secrets[1].EnvironmentVariable = %q, want %q", *step.Secrets[1].EnvironmentVariable, "API_TOKEN")
+	if diff := cmp.Diff(step.Secrets, want); diff != "" {
+		t.Errorf("step.Secrets mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/step_command_secrets_test.go
+++ b/step_command_secrets_test.go
@@ -40,14 +40,9 @@ func TestCommandStepSecretsStringArrayFormat(t *testing.T) {
 		t.Fatalf("len(steps) = %d, want 2", len(steps))
 	}
 
-	databaseURL := "DATABASE_URL"
-	apiToken := "API_TOKEN"
-	sshKey := "SSH_KEY"
-	redisURL := "REDIS_URL"
-
 	want := Secrets{
-		&Secret{Key: "DATABASE_URL", EnvironmentVariable: &databaseURL},
-		&Secret{Key: "API_TOKEN", EnvironmentVariable: &apiToken},
+		Secret{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
+		Secret{Key: "API_TOKEN", EnvironmentVariable: "API_TOKEN"},
 	}
 
 	if diff := cmp.Diff(steps[0].Secrets, want); diff != "" {
@@ -55,8 +50,8 @@ func TestCommandStepSecretsStringArrayFormat(t *testing.T) {
 	}
 
 	want = Secrets{
-		&Secret{Key: "SSH_KEY", EnvironmentVariable: &sshKey},
-		&Secret{Key: "REDIS_URL", EnvironmentVariable: &redisURL},
+		Secret{Key: "SSH_KEY", EnvironmentVariable: "SSH_KEY"},
+		Secret{Key: "REDIS_URL", EnvironmentVariable: "REDIS_URL"},
 	}
 
 	if diff := cmp.Diff(steps[1].Secrets, want); diff != "" {
@@ -94,22 +89,17 @@ secrets: null
 func TestCommandStepMergeSecretsFromPipeline(t *testing.T) {
 	t.Parallel()
 
-	// Test merging pipeline secrets with step secrets
-	apiToken := "API_TOKEN"
-	dbUrl := "DATABASE_URL"
-	redisUrl := "REDIS_URL"
-
-	step := &CommandStep{
+	step := CommandStep{
 		Command: "echo hello",
 		Secrets: Secrets{
-			&Secret{Key: "API_KEY", EnvironmentVariable: &apiToken},
-			&Secret{Key: "DB_OVERRIDE", EnvironmentVariable: &dbUrl}, // Should override pipeline
+			Secret{Key: "API_KEY", EnvironmentVariable: "API_TOKEN"},
+			Secret{Key: "DB_OVERRIDE", EnvironmentVariable: "DATABASE_URL"}, // Should override pipeline
 		},
 	}
 
 	pipelineSecrets := Secrets{
-		&Secret{Key: "DB_KEY", EnvironmentVariable: &dbUrl},       // Will be overridden
-		&Secret{Key: "REDIS_KEY", EnvironmentVariable: &redisUrl}, // Will be added
+		Secret{Key: "DB_KEY", EnvironmentVariable: "DATABASE_URL"}, // Will be overridden
+		Secret{Key: "REDIS_KEY", EnvironmentVariable: "REDIS_URL"}, // Will be added
 	}
 
 	step.MergeSecretsFromPipeline(pipelineSecrets)
@@ -119,9 +109,9 @@ func TestCommandStepMergeSecretsFromPipeline(t *testing.T) {
 	}
 
 	want := Secrets{
-		&Secret{Key: "API_KEY", EnvironmentVariable: &apiToken},
-		&Secret{Key: "DB_OVERRIDE", EnvironmentVariable: &dbUrl},
-		&Secret{Key: "REDIS_KEY", EnvironmentVariable: &redisUrl},
+		Secret{Key: "API_KEY", EnvironmentVariable: "API_TOKEN"},
+		Secret{Key: "DB_OVERRIDE", EnvironmentVariable: "DATABASE_URL"},
+		Secret{Key: "REDIS_KEY", EnvironmentVariable: "REDIS_URL"},
 	}
 
 	if diff := cmp.Diff(step.Secrets, want); diff != "" {
@@ -138,8 +128,6 @@ secrets:
   - DATABASE_URL
   - API_TOKEN
 `
-	apiToken := "API_TOKEN"
-	dbUrl := "DATABASE_URL"
 
 	var step CommandStep
 	var node yaml.Node
@@ -158,8 +146,8 @@ secrets:
 	}
 
 	want := Secrets{
-		&Secret{Key: "DATABASE_URL", EnvironmentVariable: &dbUrl},
-		&Secret{Key: "API_TOKEN", EnvironmentVariable: &apiToken},
+		Secret{Key: "DATABASE_URL", EnvironmentVariable: "DATABASE_URL"},
+		Secret{Key: "API_TOKEN", EnvironmentVariable: "API_TOKEN"},
 	}
 
 	if diff := cmp.Diff(step.Secrets, want); diff != "" {


### PR DESCRIPTION
This adds a new secrets field to command steps. This allows using Buildkite Secrets in `pipeline.yml`. Secrets can be included at both the pipeline level and step level, with step secrets taking precedence.

Basic usage:
```yaml
steps:
  - command: "deploy.sh"
     secrets:
       - DATABASE_URL
       - API_TOKEN
```

Pipeline and step secrets merge together:
```yaml
secrets:
  - DATABASE_URL
  - REDIS_URL

steps:
  - command: "test.sh"
    secrets:
      - API_TOKEN        # Step-specific secret
      - DATABASE_URL

  - command: "deploy.sh" # Includes (DATABASE_URL, REDIS_URL, API_TOKEN)
```

For now this only supports the simple string array format where the secret key becomes the environment variable name. The Secret struct is designed to support future extensions like custom environment variable names, file secrets, SSH keys, etc.

Secrets are included in signed pipelines when then the step has secrets.