### PR TITLE
Migrate to go.yaml.in/yaml/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gowebpki/jcs v1.0.1
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/oleiade/reflections v1.1.0
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v3 v3.0.4
 	gotest.tools/v3 v3.5.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
 golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=

--- a/ordered/map.go
+++ b/ordered/map.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var _ interface {

--- a/ordered/map_test.go
+++ b/ordered/map_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestMapGet(t *testing.T) {

--- a/ordered/unmarshal.go
+++ b/ordered/unmarshal.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/buildkite/go-pipeline/warning"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Errors that can be returned by Unmarshal

--- a/ordered/unmarshal_test.go
+++ b/ordered/unmarshal_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/buildkite/go-pipeline/warning"
 	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var (

--- a/ordered/yaml.go
+++ b/ordered/yaml.go
@@ -3,7 +3,7 @@ package ordered
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // DecodeYAML recursively unmarshals n into a generic type (any, []any, or
@@ -135,7 +135,7 @@ func rangeYAMLMapImpl(merged map[*yaml.Node]bool, n *yaml.Node, f func(key strin
 
 	switch n.Kind {
 	case yaml.MappingNode:
-		// gopkg.in/yaml.v3 parses mapping node contents as a flat list:
+		// go.yaml.in/yaml/v3 parses mapping node contents as a flat list:
 		// key, value, key, value...
 		if len(n.Content)%2 != 0 {
 			return fmt.Errorf("line %d, col %d: mapping node has odd content length %d", n.Line, n.Column, len(n.Content))

--- a/parser.go
+++ b/parser.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/buildkite/go-pipeline/ordered"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Options are functional options for creating a new Env.

--- a/parser_test.go
+++ b/parser_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/buildkite/go-pipeline/ordered"
 	"github.com/buildkite/go-pipeline/warning"
 	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func ptr[T any](x T) *T { return &x }

--- a/pipeline_secrets_test.go
+++ b/pipeline_secrets_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/buildkite/go-pipeline/ordered"
 	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestPipelineSecretsUnmarshal(t *testing.T) {

--- a/plugin.go
+++ b/plugin.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var (

--- a/plugins.go
+++ b/plugins.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/buildkite/go-pipeline/ordered"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var _ interface {

--- a/secret_test.go
+++ b/secret_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/buildkite/interpolate"
 	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestSecretMarshalJSON(t *testing.T) {

--- a/secrets.go
+++ b/secrets.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/buildkite/go-pipeline/ordered"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var _ interface {

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/buildkite/go-pipeline/ordered"
 	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestSecretsUnmarshalJSON(t *testing.T) {

--- a/step_command.go
+++ b/step_command.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/buildkite/go-pipeline/ordered"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var _ interface {

--- a/step_command_matrix.go
+++ b/step_command_matrix.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 
 	"github.com/buildkite/go-pipeline/ordered"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var (

--- a/step_command_secrets_test.go
+++ b/step_command_secrets_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/buildkite/go-pipeline/ordered"
 	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestCommandStepSecretsStringArrayFormat(t *testing.T) {


### PR DESCRIPTION
Migrate from `gopkg.in/yaml.v3`, which is no longer maintained, to `go.yaml.in/yaml/v3`, a fork maintained by the YAML org.