### PR TITLE
Change the CommandStep and Plugins processing to allow control characters

### DIFF
--- a/ordered/json.go
+++ b/ordered/json.go
@@ -1,0 +1,112 @@
+package ordered
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
+// DecodeJSON decodes JSON bytes into the same generic types that DecodeYAML
+// produces: *Map[string, any] for objects, []any for arrays, and string,
+// int, float64, bool, or nil for scalars.
+//
+// Unlike DecodeYAML, this uses encoding/json directly and therefore correctly
+// handles all JSON-valid characters (including control characters that yaml.v3
+// rejects).
+func DecodeJSON(b []byte) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+	return decodeJSONValue(dec)
+}
+
+func decodeJSONValue(dec *json.Decoder) (any, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	switch t := tok.(type) {
+	case json.Delim:
+		switch t {
+		case '{':
+			return decodeJSONObject(dec)
+		case '[':
+			return decodeJSONArray(dec)
+		default:
+			return nil, fmt.Errorf("unexpected JSON delimiter %q", t)
+		}
+
+	case json.Number:
+		// Try int first, then float, matching yaml.v3 behaviour.
+		if i, err := t.Int64(); err == nil {
+			return int(i), nil
+		}
+		f, err := t.Float64()
+		if err != nil {
+			return nil, fmt.Errorf("decoding JSON number %q: %w", t, err)
+		}
+		// If the float is a whole number that fits in an int, return int.
+		if f == math.Trunc(f) && !math.IsInf(f, 0) && f >= math.MinInt && f <= math.MaxInt {
+			return int(int64(f)), nil
+		}
+		return f, nil
+
+	case string:
+		return t, nil
+
+	case bool:
+		return t, nil
+
+	case nil:
+		return nil, nil
+
+	default:
+		return nil, fmt.Errorf("unexpected JSON token type %T", tok)
+	}
+}
+
+func decodeJSONObject(dec *json.Decoder) (*Map[string, any], error) {
+	m := NewMap[string, any](0)
+	for dec.More() {
+		// Read the key.
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected string key in JSON object, got %T", tok)
+		}
+
+		// Read the value.
+		val, err := decodeJSONValue(dec)
+		if err != nil {
+			return nil, fmt.Errorf("decoding value for key %q: %w", key, err)
+		}
+		m.Set(key, val)
+	}
+
+	// Consume the closing '}'.
+	if _, err := dec.Token(); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func decodeJSONArray(dec *json.Decoder) ([]any, error) {
+	var arr []any
+	for dec.More() {
+		val, err := decodeJSONValue(dec)
+		if err != nil {
+			return nil, err
+		}
+		arr = append(arr, val)
+	}
+
+	// Consume the closing ']'.
+	if _, err := dec.Token(); err != nil {
+		return nil, err
+	}
+	return arr, nil
+}

--- a/plugins.go
+++ b/plugins.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/buildkite/go-pipeline/ordered"
-	"gopkg.in/yaml.v3"
 )
 
 var _ interface {
@@ -97,10 +96,9 @@ func (p *Plugins) UnmarshalOrdered(o any) error {
 
 // UnmarshalJSON is used mainly to normalise the BUILDKITE_PLUGINS env var.
 func (p *Plugins) UnmarshalJSON(b []byte) error {
-	// JSON is just a specific kind of YAML.
-	var n yaml.Node
-	if err := yaml.Unmarshal(b, &n); err != nil {
-		return err
+	src, err := ordered.DecodeJSON(b)
+	if err != nil {
+		return fmt.Errorf("decoding JSON for Plugins: %w", err)
 	}
-	return ordered.Unmarshal(&n, &p)
+	return ordered.Unmarshal(src, p)
 }

--- a/step_command.go
+++ b/step_command.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/buildkite/go-pipeline/ordered"
-	"gopkg.in/yaml.v3"
 )
 
 var _ interface {
@@ -53,12 +52,11 @@ func (c *CommandStep) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON is used when unmarshalling an individual step directly, e.g.
 // from the Agent API Accept Job.
 func (c *CommandStep) UnmarshalJSON(b []byte) error {
-	// JSON is just a specific kind of YAML.
-	var n yaml.Node
-	if err := yaml.Unmarshal(b, &n); err != nil {
-		return err
+	src, err := ordered.DecodeJSON(b)
+	if err != nil {
+		return fmt.Errorf("decoding JSON for CommandStep: %w", err)
 	}
-	return ordered.Unmarshal(&n, &c)
+	return ordered.Unmarshal(src, c)
 }
 
 // UnmarshalOrdered unmarshals a command step from an ordered map.

--- a/step_command_test.go
+++ b/step_command_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/buildkite/go-pipeline/ordered"
@@ -76,6 +77,97 @@ func TestCommandStepUnmarshalJSON(t *testing.T) {
 
 	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSA)); diff != "" {
 		t.Errorf("CommandStep diff after UnmarshalJSON (-got +want):\n%s", diff)
+	}
+}
+
+func TestCommandStepUnmarshalJSON_ControlCharacters(t *testing.T) {
+	// JSON allows control characters via escape sequences (e.g. \b, \f, \t)
+	// that yaml.v3 rejects. This test ensures they survive unmarshalling.
+	input := []byte(`{
+  "command": "echo \"hello\tworld\"",
+  "label": "test\b\f"
+}`)
+
+	want := &CommandStep{
+		Command: "echo \"hello\tworld\"",
+		Label:   "test\b\f",
+	}
+
+	got := new(CommandStep)
+	if err := got.UnmarshalJSON(input); err != nil {
+		t.Fatalf("CommandStep.UnmarshalJSON(input) = %v", err)
+	}
+
+	if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSA)); diff != "" {
+		t.Errorf("CommandStep diff after UnmarshalJSON (-got +want):\n%s", diff)
+	}
+}
+
+func TestCommandStepUnmarshalJSON_C1ControlCharacters(t *testing.T) {
+	// Mojibake smart quotes: â\x80\x9c and â\x80\x9d contain C1 control
+	// characters (U+0080, U+009C, U+009D) that yaml.v3 rejects but are
+	// valid in JSON via \uXXXX escapes.
+	input := []byte(`[
+  {
+    "command": "echo foo",
+    "label": "FOO",
+    "agents": {"queue": "default"}
+  },
+  {
+    "command": "echo bar",
+    "label": "BAR",
+    "agents": {"queue": "default"}
+  },
+  {
+    "command": "echo \u00e2\u0080\u009cApplication Agreement.\u00e2\u0080\u009d",
+    "label": "BOOM",
+    "agents": {"queue": "default"}
+  }
+]`)
+
+	agentsMap := ordered.NewMap[string, any](1)
+	agentsMap.Set("queue", "default")
+
+	wantSteps := []*CommandStep{
+		{
+			Command: "echo foo",
+			Label:   "FOO",
+			RemainingFields: map[string]any{
+				"agents": agentsMap,
+			},
+		},
+		{
+			Command: "echo bar",
+			Label:   "BAR",
+			RemainingFields: map[string]any{
+				"agents": agentsMap,
+			},
+		},
+		{
+			Command: "echo \u00e2\u0080\u009cApplication Agreement.\u00e2\u0080\u009d",
+			Label:   "BOOM",
+			RemainingFields: map[string]any{
+				"agents": agentsMap,
+			},
+		},
+	}
+
+	for i, want := range wantSteps {
+		// Each element in the JSON array is a separate step object.
+		// Extract each object individually.
+		var steps []json.RawMessage
+		if err := json.Unmarshal(input, &steps); err != nil {
+			t.Fatalf("json.Unmarshal(input) = %v", err)
+		}
+
+		got := new(CommandStep)
+		if err := got.UnmarshalJSON(steps[i]); err != nil {
+			t.Fatalf("CommandStep[%d].UnmarshalJSON() = %v", i, err)
+		}
+
+		if diff := cmp.Diff(got, want, cmp.Comparer(ordered.EqualSA)); diff != "" {
+			t.Errorf("CommandStep[%d] diff after UnmarshalJSON (-got +want):\n%s", i, diff)
+		}
 	}
 }
 


### PR DESCRIPTION
We've found that control characters in certain pipeline yaml fields causes a Job to be canceled by the agent, tracing through this is due to the parsing by `gopkg.in/yaml.v3` having a specific allow list of certain control characters and erroring out on any others.

As we would prefer to allow these (valid) characters to still be present, while also ensuring we have the benefits (ordering) of the yaml parsing, we can switch to a custom json parse method. This preserves the existing behaviour while also allowing additional characters to be present.

Existing tests continue to pass, and new tests have been added to validate that the presence of known formerly breaking characters are now valid to be used.

Resolves A-1170.