### PR TITLE
Add `checkout.skip` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ steps:
       skip: true
 ```
 
-`skip: false` at the step level explicitly overrides any pipeline-level or agent-level default that would otherwise skip checkout, while an absent `skip` inherits whatever default applies. Round-trips preserve the distinction; `skip: false` does not collapse to an empty mapping. `submodules` follows the same tristate pattern and maps to `BUILDKITE_GIT_SUBMODULES` on the agent (`true` and `false` set the env var explicitly; absent leaves it to the agent default).
+`skip: false` at the step level explicitly overrides any pipeline-level or agent-level default that would otherwise skip checkout, while an absent `skip` inherits whatever default applies. Round-trips preserve the distinction; `skip: false` does not collapse to an empty mapping. The agent reads `skip` directly from the job payload (there is no equivalent agent env var override). `submodules` follows the same tristate pattern and maps to `BUILDKITE_GIT_SUBMODULES` on the agent (`true` and `false` set the env var explicitly; absent leaves it to the agent default).
 
-A pipeline-level `checkout` provides defaults for command steps. Inheritance is opt-in: the consumer must call `step.MergeCheckoutFromPipeline(pipeline.Checkout)` per step. After that call the step value wins per leaf, with anything the step didn't set inherited from the pipeline:
+A pipeline-level `checkout` provides defaults for command steps. Inheritance is opt-in: the consumer merges pipeline values into each step. After merging the step value wins per leaf, with anything the step didn't set inherited from the pipeline:
 
 ```yaml
 checkout:
@@ -156,7 +156,11 @@ steps:
 
 After merging, the second step has `skip: false` (step wins) and the first step has `skip: true` (inherited).
 
+Run `Pipeline.Interpolate` first, then merge per step. Merging first then interpolating would re-interpolate pipeline values inside each step's environment scope.
+
 `checkout: false` (and `checkout: true`) as a shorthand is rejected at unmarshal time; `checkout` is a mapping, so opt-out is spelled `checkout: { skip: true }`.
+
+Pipelines signed before checkout was a signed field will fail to verify if the step now carries any non-empty Checkout data (for example a step that sets only `submodules`). Re-sign such pipelines when rolling forward to a verifier that includes checkout.
 
 ## What's up with the ordered module?
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,37 @@ would be represented in go as:
 
 This go struct would be marshaled back out to YAML equivalent to the original input.
 
+## Checkout
+
+The `checkout` block configures git checkout behaviour for a pipeline or a command step. The simplest case opts a step out of checkout entirely:
+
+```yaml
+steps:
+  - command: echo "no git checkout for me"
+    checkout:
+      skip: true
+```
+
+`Checkout.Skip` is a `*bool` so the model preserves the difference between `skip: true`, `skip: false`, and an absent `skip`. This matters because `skip: false` at the step level explicitly overrides any pipeline-level or agent-level default that would otherwise skip checkout, while an absent `skip` inherits whatever default applies. Round-trips preserve the distinction; `skip: false` does not collapse to an empty mapping.
+
+A pipeline-level `checkout` is inherited by command steps that do not set their own. The step value wins per leaf when both are set:
+
+```yaml
+checkout:
+  skip: true
+
+steps:
+  - command: echo "inherits skip: true from the pipeline"
+
+  - command: echo "explicit override - checkout runs"
+    checkout:
+      skip: false
+```
+
+After calling `step.MergeCheckoutFromPipeline(pipeline.Checkout)` on the second step, the merged result has `skip: false` (step wins). The first step inherits `skip: true` from the pipeline.
+
+`checkout: false` as a shorthand is rejected at unmarshal time; `checkout` is a multi-field namespace, so opt-out is spelled `checkout: { skip: true }`.
+
 ## What's up with the ordered module?
 
 While implementing the pipeline module, we ran into a problem: in some cases, in the buildkite pipeline.yaml, the order of map fields is significant. Because of this, whenever the pipeline gets unmarshaled from YAML or JSON, it needs to be stored in a way that preserves the order of the fields. The `ordered` module is a simple implementation of an ordered map. In most cases, when the pipeline is dealing with user-input maps, it will store them internally as `ordered.Map`s. When the pipeline is marshaled back out to YAML or JSON, the `ordered.Map`s will be marshaled in the correct order.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ This go struct would be marshaled back out to YAML equivalent to the original in
 
 ## Checkout
 
-The `checkout` block configures git checkout behaviour for a pipeline or a command step. The simplest case opts a step out of checkout entirely:
+The `checkout` block configures git checkout behavior for a pipeline or a command step. Two fields are supported today: `skip` and `submodules`. Both are `*bool` so the model preserves the difference between `true`, `false`, and an absent value.
+
+The simplest case opts a step out of checkout entirely:
 
 ```yaml
 steps:
@@ -136,9 +138,9 @@ steps:
       skip: true
 ```
 
-`Checkout.Skip` is a `*bool` so the model preserves the difference between `skip: true`, `skip: false`, and an absent `skip`. This matters because `skip: false` at the step level explicitly overrides any pipeline-level or agent-level default that would otherwise skip checkout, while an absent `skip` inherits whatever default applies. Round-trips preserve the distinction; `skip: false` does not collapse to an empty mapping.
+`skip: false` at the step level explicitly overrides any pipeline-level or agent-level default that would otherwise skip checkout, while an absent `skip` inherits whatever default applies. Round-trips preserve the distinction; `skip: false` does not collapse to an empty mapping. `submodules` follows the same tristate pattern and maps to `BUILDKITE_GIT_SUBMODULES` on the agent (`true` and `false` set the env var explicitly; absent leaves it to the agent default).
 
-A pipeline-level `checkout` is inherited by command steps that do not set their own. The step value wins per leaf when both are set:
+A pipeline-level `checkout` provides defaults for command steps. Inheritance is opt-in: the consumer must call `step.MergeCheckoutFromPipeline(pipeline.Checkout)` per step. After that call the step value wins per leaf, with anything the step didn't set inherited from the pipeline:
 
 ```yaml
 checkout:
@@ -152,9 +154,9 @@ steps:
       skip: false
 ```
 
-After calling `step.MergeCheckoutFromPipeline(pipeline.Checkout)` on the second step, the merged result has `skip: false` (step wins). The first step inherits `skip: true` from the pipeline.
+After merging, the second step has `skip: false` (step wins) and the first step has `skip: true` (inherited).
 
-`checkout: false` as a shorthand is rejected at unmarshal time; `checkout` is a multi-field namespace, so opt-out is spelled `checkout: { skip: true }`.
+`checkout: false` (and `checkout: true`) as a shorthand is rejected at unmarshal time; `checkout` is a mapping, so opt-out is spelled `checkout: { skip: true }`.
 
 ## What's up with the ordered module?
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ steps:
 
 After merging, the second step has `skip: false` (step wins) and the first step has `skip: true` (inherited).
 
-Run `Pipeline.Interpolate` first, then merge per step. Merging first then interpolating would re-interpolate pipeline values inside each step's environment scope.
+The conventional ordering is `Pipeline.Interpolate` first, then merge per step before dispatching to the agent.
 
 `checkout: false` (and `checkout: true`) as a shorthand is rejected at unmarshal time; `checkout` is a mapping, so opt-out is spelled `checkout: { skip: true }`.
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ steps:
       skip: true
 ```
 
-`skip: false` at the step level explicitly overrides any pipeline-level or agent-level default that would otherwise skip checkout, while an absent `skip` inherits whatever default applies. Round-trips preserve the distinction; `skip: false` does not collapse to an empty mapping. The agent reads `skip` directly from the job payload (there is no equivalent agent env var override). `submodules` follows the same tristate pattern and maps to `BUILDKITE_GIT_SUBMODULES` on the agent (`true` and `false` set the env var explicitly; absent leaves it to the agent default).
+`skip: false` at the step level explicitly overrides any pipeline-level or agent-level default that would otherwise skip checkout, while an absent `skip` inherits whatever default applies. Round-trips preserve the distinction; `skip: false` does not collapse to an empty mapping. `skip` maps to `BUILDKITE_SKIP_CHECKOUT` on the agent (`true` skips the checkout phase; absent leaves it to the agent default). `submodules` follows the same tristate pattern and maps to `BUILDKITE_GIT_SUBMODULES` on the agent (`true` and `false` set the env var explicitly; absent leaves it to the agent default).
 
 A pipeline-level `checkout` provides defaults for command steps. Inheritance is opt-in: the consumer merges pipeline values into each step. After merging the step value wins per leaf, with anything the step didn't set inherited from the pipeline:
 

--- a/checkout.go
+++ b/checkout.go
@@ -68,10 +68,13 @@ func (c *Checkout) UnmarshalOrdered(o any) error {
 	}
 }
 
-// interpolate is a no-op today: Skip and Submodules are *bool, and
-// RemainingFields is not traversed.
-func (c *Checkout) interpolate(stringTransformer) error {
-	return nil
+// interpolate satisfies selfInterpolater. Skip and Submodules are *bool and
+// have nothing to transform; RemainingFields gets the same treatment as on
+// CommandStep/Pipeline/Matrix so `${VAR}` references inside future or
+// forward-compat checkout fields are interpolated rather than passed through
+// verbatim.
+func (c *Checkout) interpolate(tf stringTransformer) error {
+	return interpolateMap(tf, c.RemainingFields)
 }
 
 // mergeFrom merges parent values into c. Child wins per top-level key;

--- a/checkout.go
+++ b/checkout.go
@@ -1,0 +1,91 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/buildkite/go-pipeline/ordered"
+)
+
+var _ interface {
+	json.Marshaler
+	ordered.Unmarshaler
+	selfInterpolater
+} = (*Checkout)(nil)
+
+var errUnsupportedCheckoutType = fmt.Errorf("unsupported type for checkout")
+
+// Checkout models the checkout configuration for a pipeline or command step.
+type Checkout struct {
+	// Skip is *bool to preserve the tristate distinction (true / false / absent).
+	// `bool` plus `omitempty` would collapse `skip: false` and an absent `skip`
+	// field into the same empty output.
+	Skip *bool `yaml:"skip,omitempty"`
+
+	// RemainingFields stores any other top-level mapping items so they at least
+	// survive an unmarshal-marshal round-trip.
+	RemainingFields map[string]any `yaml:",inline"`
+}
+
+// MarshalJSON marshals the checkout to JSON. Special handling is needed because
+// yaml.v3 has "inline" but encoding/json has no concept of it.
+func (c *Checkout) MarshalJSON() ([]byte, error) {
+	return inlineFriendlyMarshalJSON(c)
+}
+
+// IsEmpty reports whether the checkout is empty (is nil, or has no Skip and
+// no other data within it). Used by signing to canonicalise empty/nil values.
+func (c *Checkout) IsEmpty() bool {
+	return c == nil || (c.Skip == nil && len(c.RemainingFields) == 0)
+}
+
+// UnmarshalOrdered unmarshals a Checkout from an ordered map. Bool inputs are
+// rejected; see the error message for the supported form.
+func (c *Checkout) UnmarshalOrdered(o any) error {
+	switch v := o.(type) {
+	case bool:
+		return fmt.Errorf("unmarshaling checkout: bool is not a valid value; use checkout.skip (e.g. checkout: { skip: %t }) instead", v)
+
+	case *ordered.MapSA:
+		type wrappedCheckout Checkout
+		if err := ordered.Unmarshal(o, (*wrappedCheckout)(c)); err != nil {
+			return fmt.Errorf("unmarshaling checkout: %w", err)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unmarshaling checkout: %w: got %T, want a mapping with checkout.skip and other fields", errUnsupportedCheckoutType, o)
+	}
+}
+
+// interpolate is a no-op today: Skip is *bool, and RemainingFields is not
+// traversed.
+func (c *Checkout) interpolate(stringTransformer) error {
+	return nil
+}
+
+// mergeFrom merges parent values into c. Child wins per top-level key;
+// parent contributes only keys the child does not set.
+func (c *Checkout) mergeFrom(parent *Checkout) {
+	if c == nil || parent == nil {
+		return
+	}
+
+	if c.Skip == nil && parent.Skip != nil {
+		v := *parent.Skip
+		c.Skip = &v
+	}
+
+	if len(parent.RemainingFields) == 0 {
+		return
+	}
+	if c.RemainingFields == nil {
+		c.RemainingFields = make(map[string]any, len(parent.RemainingFields))
+	}
+	for k, pv := range parent.RemainingFields {
+		if _, ok := c.RemainingFields[k]; ok {
+			continue
+		}
+		c.RemainingFields[k] = pv
+	}
+}

--- a/checkout.go
+++ b/checkout.go
@@ -17,18 +17,20 @@ var errUnsupportedCheckoutType = fmt.Errorf("unsupported type for checkout")
 
 // Checkout models pipeline- or step-level git checkout settings. Step-level
 // values override pipeline-level values per property.
+//
+// Direct json.Unmarshal into a Checkout drops inline RemainingFields; route
+// through CommandStep or Pipeline to preserve them.
 type Checkout struct {
-	// Skip is *bool to preserve the tristate distinction (true / false / absent).
-	// `bool` plus `omitempty` would collapse `skip: false` and an absent `skip`
-	// field into the same empty output.
+	// Skip is *bool so the tristate (true / false / absent) survives a
+	// round-trip; `bool` plus `omitempty` would collapse `skip: false` and
+	// an absent `skip` into the same output.
 	Skip *bool `yaml:"skip,omitempty"`
 
-	// Submodules maps to BUILDKITE_GIT_SUBMODULES on the agent. nil = unset
-	// (agent uses its default, currently true); true/false set the env var
-	// explicitly.
+	// Submodules maps to BUILDKITE_GIT_SUBMODULES on the agent. nil leaves
+	// the agent default; true/false set the env var explicitly.
 	Submodules *bool `yaml:"submodules,omitempty"`
 
-	// RemainingFields stores any other top-level mapping items so they at least
+	// RemainingFields stores any other top-level mapping items so they
 	// survive an unmarshal-marshal round-trip.
 	RemainingFields map[string]any `yaml:",inline"`
 }
@@ -39,9 +41,8 @@ func (c *Checkout) MarshalJSON() ([]byte, error) {
 	return inlineFriendlyMarshalJSON(c)
 }
 
-// IsEmpty reports whether the checkout is empty (is nil, or has no known
-// fields set and no remaining data). Used by signing to canonicalise
-// empty/nil values.
+// IsEmpty reports whether the checkout is nil or has no fields set.
+// Used by signing to canonicalise empty/nil values.
 func (c *Checkout) IsEmpty() bool {
 	return c == nil || (c.Skip == nil && c.Submodules == nil && len(c.RemainingFields) == 0)
 }
@@ -68,11 +69,6 @@ func (c *Checkout) UnmarshalOrdered(o any) error {
 	}
 }
 
-// interpolate satisfies selfInterpolater. Skip and Submodules are *bool and
-// have nothing to transform; RemainingFields gets the same treatment as on
-// CommandStep/Pipeline/Matrix so `${VAR}` references inside future or
-// forward-compat checkout fields are interpolated rather than passed through
-// verbatim.
 func (c *Checkout) interpolate(tf stringTransformer) error {
 	return interpolateMap(tf, c.RemainingFields)
 }
@@ -108,10 +104,11 @@ func (c *Checkout) mergeFrom(parent *Checkout) {
 	}
 }
 
-// cloneAny deep-copies the value shapes that appear in inline RemainingFields:
-// nested map[string]any, []any, and *ordered.MapSA. Other types (scalars,
-// concrete typed values) are returned by value, which is safe for the
-// immutable types YAML/JSON decode into.
+// cloneAny deep-copies the value shapes YAML/JSON decoding produces in inline
+// RemainingFields: nested map[string]any, []any, and *ordered.MapSA. Other
+// types fall through by value; callers that put typed reference values
+// (e.g. []string, map[string]string) into RemainingFields programmatically
+// are responsible for their own copies before merging.
 func cloneAny(v any) any {
 	switch v := v.(type) {
 	case map[string]any:

--- a/checkout.go
+++ b/checkout.go
@@ -51,7 +51,10 @@ func (c *Checkout) IsEmpty() bool {
 func (c *Checkout) UnmarshalOrdered(o any) error {
 	switch v := o.(type) {
 	case bool:
-		return fmt.Errorf("unmarshaling checkout: bool is not a valid value; use checkout.skip (e.g. checkout: { skip: %t }) instead", v)
+		if v {
+			return fmt.Errorf("unmarshaling checkout: 'checkout: true' is not a valid value; checkout runs by default, so omit the field (or use 'checkout: { skip: false }' to opt in explicitly)")
+		}
+		return fmt.Errorf("unmarshaling checkout: 'checkout: false' is not a valid value; use 'checkout: { skip: true }' to opt out of checkout")
 
 	case *ordered.MapSA:
 		type wrappedCheckout Checkout

--- a/checkout.go
+++ b/checkout.go
@@ -104,6 +104,42 @@ func (c *Checkout) mergeFrom(parent *Checkout) {
 		if _, ok := c.RemainingFields[k]; ok {
 			continue
 		}
-		c.RemainingFields[k] = pv
+		c.RemainingFields[k] = cloneAny(pv)
+	}
+}
+
+// cloneAny deep-copies the value shapes that appear in inline RemainingFields:
+// nested map[string]any, []any, and *ordered.MapSA. Other types (scalars,
+// concrete typed values) are returned by value, which is safe for the
+// immutable types YAML/JSON decode into.
+func cloneAny(v any) any {
+	switch v := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for k, vv := range v {
+			out[k] = cloneAny(vv)
+		}
+		return out
+
+	case []any:
+		out := make([]any, len(v))
+		for i, vv := range v {
+			out[i] = cloneAny(vv)
+		}
+		return out
+
+	case *ordered.MapSA:
+		if v == nil {
+			return (*ordered.MapSA)(nil)
+		}
+		out := ordered.NewMap[string, any](v.Len())
+		_ = v.Range(func(k string, vv any) error {
+			out.Set(k, cloneAny(vv))
+			return nil
+		})
+		return out
+
+	default:
+		return v
 	}
 }

--- a/checkout.go
+++ b/checkout.go
@@ -52,9 +52,9 @@ func (c *Checkout) UnmarshalOrdered(o any) error {
 	switch v := o.(type) {
 	case bool:
 		if v {
-			return fmt.Errorf("unmarshaling checkout: 'checkout: true' is not a valid value; checkout runs by default, so omit the field (or use 'checkout: { skip: false }' to opt in explicitly)")
+			return fmt.Errorf("unmarshaling checkout: 'checkout: true' is not valid; omit the field or use 'checkout: { skip: false }'")
 		}
-		return fmt.Errorf("unmarshaling checkout: 'checkout: false' is not a valid value; use 'checkout: { skip: true }' to opt out of checkout")
+		return fmt.Errorf("unmarshaling checkout: 'checkout: false' is not valid; use 'checkout: { skip: true }' to opt out")
 
 	case *ordered.MapSA:
 		type wrappedCheckout Checkout
@@ -64,7 +64,7 @@ func (c *Checkout) UnmarshalOrdered(o any) error {
 		return nil
 
 	default:
-		return fmt.Errorf("unmarshaling checkout: %w: got %T, want a mapping with checkout fields", errUnsupportedCheckoutType, o)
+		return fmt.Errorf("%w: %T", errUnsupportedCheckoutType, o)
 	}
 }
 

--- a/checkout_test.go
+++ b/checkout_test.go
@@ -257,11 +257,26 @@ func TestCheckoutUnmarshalRejectsBool(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name  string
-		input any
+		name      string
+		input     bool
+		wantParts []string
 	}{
-		{name: "false", input: false},
-		{name: "true", input: true},
+		{
+			name:  "false suggests opt-out",
+			input: false,
+			// 'checkout: false' was an opt-out attempt; the error must point
+			// at 'skip: true' (not 'skip: false') so the user's intent isn't
+			// inverted.
+			wantParts: []string{"'checkout: false'", "skip: true", "opt out"},
+		},
+		{
+			name:  "true suggests omit-or-opt-in",
+			input: true,
+			// 'checkout: true' was either redundant or an explicit opt-in; the
+			// error must point at omitting the field or 'skip: false', not at
+			// the opt-out form.
+			wantParts: []string{"'checkout: true'", "skip: false", "omit"},
+		},
 	}
 
 	for _, tc := range cases {
@@ -273,8 +288,10 @@ func TestCheckoutUnmarshalRejectsBool(t *testing.T) {
 			if err == nil {
 				t.Fatalf("Checkout.UnmarshalOrdered(%v) error = nil, want error", tc.input)
 			}
-			if !strings.Contains(err.Error(), "checkout.skip") {
-				t.Errorf("Checkout.UnmarshalOrdered(%v) error = %q, want it to mention %q", tc.input, err, "checkout.skip")
+			for _, part := range tc.wantParts {
+				if !strings.Contains(err.Error(), part) {
+					t.Errorf("Checkout.UnmarshalOrdered(%v) error = %q, want it to contain %q", tc.input, err, part)
+				}
 			}
 		})
 	}

--- a/checkout_test.go
+++ b/checkout_test.go
@@ -1,0 +1,480 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/go-pipeline/ordered"
+	"github.com/buildkite/interpolate"
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCheckoutMarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		c    Checkout
+		want string
+	}{
+		{
+			name: "skip nil",
+			c:    Checkout{},
+			want: "{}\n",
+		},
+		{
+			name: "skip true",
+			c:    Checkout{Skip: ptr(true)},
+			want: "skip: true\n",
+		},
+		{
+			name: "skip false",
+			c:    Checkout{Skip: ptr(false)},
+			want: "skip: false\n",
+		},
+		{
+			name: "with remaining fields",
+			c: Checkout{
+				Skip:            ptr(true),
+				RemainingFields: map[string]any{"depth": 1},
+			},
+			want: "skip: true\ndepth: 1\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := yaml.Marshal(tc.c)
+			if err != nil {
+				t.Fatalf("yaml.Marshal(%#v) error = %v", tc.c, err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("yaml.Marshal(%#v) = %q, want %q", tc.c, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckoutMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		c    Checkout
+		want string
+	}{
+		{
+			name: "skip nil",
+			c:    Checkout{},
+			want: `{}`,
+		},
+		{
+			name: "skip true",
+			c:    Checkout{Skip: ptr(true)},
+			want: `{"skip":true}`,
+		},
+		{
+			name: "skip false",
+			c:    Checkout{Skip: ptr(false)},
+			want: `{"skip":false}`,
+		},
+		{
+			name: "with remaining fields",
+			c: Checkout{
+				Skip:            ptr(true),
+				RemainingFields: map[string]any{"depth": 1},
+			},
+			want: `{"depth":1,"skip":true}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(&tc.c)
+			if err != nil {
+				t.Fatalf("json.Marshal(%#v) error = %v", tc.c, err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("json.Marshal(%#v) = %q, want %q", tc.c, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckoutUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want Checkout
+	}{
+		{
+			name: "empty mapping",
+			in:   `{}`,
+			want: Checkout{},
+		},
+		{
+			name: "skip true",
+			in:   `skip: true`,
+			want: Checkout{Skip: ptr(true)},
+		},
+		{
+			name: "skip false",
+			in:   `skip: false`,
+			want: Checkout{Skip: ptr(false)},
+		},
+		{
+			name: "with extra fields",
+			in: `skip: true
+depth: 1`,
+			want: Checkout{
+				Skip:            ptr(true),
+				RemainingFields: map[string]any{"depth": 1},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c Checkout
+			var node yaml.Node
+			if err := yaml.Unmarshal([]byte(tc.in), &node); err != nil {
+				t.Fatalf("yaml.Unmarshal(%q) error = %v", tc.in, err)
+			}
+			if err := ordered.Unmarshal(&node, &c); err != nil {
+				t.Fatalf("ordered.Unmarshal error = %v", err)
+			}
+			if diff := cmp.Diff(tc.want, c, cmp.Comparer(ordered.EqualSA)); diff != "" {
+				t.Errorf("Checkout diff after unmarshal (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCheckoutUnmarshalRejectsBool(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input any
+	}{
+		{name: "false", input: false},
+		{name: "true", input: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c Checkout
+			err := c.UnmarshalOrdered(tc.input)
+			if err == nil {
+				t.Fatalf("Checkout.UnmarshalOrdered(%v) error = nil, want error", tc.input)
+			}
+			if !strings.Contains(err.Error(), "checkout.skip") {
+				t.Errorf("Checkout.UnmarshalOrdered(%v) error = %q, want it to mention %q", tc.input, err, "checkout.skip")
+			}
+		})
+	}
+}
+
+func TestCheckoutUnmarshalRejectsNonMappings(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input any
+	}{
+		{name: "string", input: "skip"},
+		{name: "int", input: 42},
+		{name: "sequence", input: []any{1, 2, 3}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c Checkout
+			err := c.UnmarshalOrdered(tc.input)
+			if err == nil {
+				t.Fatalf("Checkout.UnmarshalOrdered(%v) error = nil, want error", tc.input)
+			}
+			if !errors.Is(err, errUnsupportedCheckoutType) {
+				t.Errorf("Checkout.UnmarshalOrdered(%v) error = %q, want it to wrap errUnsupportedCheckoutType", tc.input, err)
+			}
+		})
+	}
+}
+
+func TestCheckoutUnmarshalNull(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `checkout:
+steps:
+  - command: echo hello
+`
+
+	p, err := Parse(strings.NewReader(yamlData))
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+	if p.Checkout != nil {
+		t.Errorf("p.Checkout = %v, want nil for explicit YAML null", p.Checkout)
+	}
+}
+
+func TestCheckoutUnmarshalAliases(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `_anchors:
+  base: &base
+    skip: true
+checkout: *base
+steps:
+  - command: echo hello
+    checkout: *base
+`
+
+	p, err := Parse(strings.NewReader(yamlData))
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+	if p.Checkout == nil {
+		t.Fatalf("p.Checkout = nil, want non-nil")
+	}
+	if p.Checkout.Skip == nil || *p.Checkout.Skip != true {
+		t.Errorf("p.Checkout.Skip = %v, want ptr(true)", p.Checkout.Skip)
+	}
+
+	step := p.Steps[0].(*CommandStep)
+	if step.Checkout == nil {
+		t.Fatalf("step.Checkout = nil, want non-nil")
+	}
+	if step.Checkout.Skip == nil || *step.Checkout.Skip != true {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(true)", step.Checkout.Skip)
+	}
+}
+
+func TestCheckoutRoundTripYAML(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{
+			name: "skip false survives",
+			in:   "skip: false\n",
+		},
+		{
+			name: "skip true survives",
+			in:   "skip: true\n",
+		},
+		{
+			name: "empty mapping",
+			in:   "{}\n",
+		},
+		{
+			name: "unknown fields preserved",
+			in: `depth: 1
+submodules: false
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c Checkout
+			var node yaml.Node
+			if err := yaml.Unmarshal([]byte(tc.in), &node); err != nil {
+				t.Fatalf("yaml.Unmarshal(%q) error = %v", tc.in, err)
+			}
+			if err := ordered.Unmarshal(&node, &c); err != nil {
+				t.Fatalf("ordered.Unmarshal error = %v", err)
+			}
+
+			out, err := yaml.Marshal(c)
+			if err != nil {
+				t.Fatalf("yaml.Marshal error = %v", err)
+			}
+
+			// Re-unmarshal to compare structurally.
+			var c2 Checkout
+			var node2 yaml.Node
+			if err := yaml.Unmarshal(out, &node2); err != nil {
+				t.Fatalf("yaml.Unmarshal(%q) error = %v", out, err)
+			}
+			if err := ordered.Unmarshal(&node2, &c2); err != nil {
+				t.Fatalf("ordered.Unmarshal round-trip error = %v", err)
+			}
+
+			if diff := cmp.Diff(c, c2, cmp.Comparer(ordered.EqualSA)); diff != "" {
+				t.Errorf("Checkout round-trip diff (-orig +new):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCheckoutRoundTripJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{name: "skip false", in: `{"skip":false}`},
+		{name: "skip true", in: `{"skip":true}`},
+		{name: "empty", in: `{}`},
+		{name: "with remaining", in: `{"depth":1,"skip":true}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c Checkout
+			src, err := ordered.DecodeJSON([]byte(tc.in))
+			if err != nil {
+				t.Fatalf("ordered.DecodeJSON(%q) error = %v", tc.in, err)
+			}
+			if err := ordered.Unmarshal(src, &c); err != nil {
+				t.Fatalf("ordered.Unmarshal error = %v", err)
+			}
+
+			out, err := json.Marshal(&c)
+			if err != nil {
+				t.Fatalf("json.Marshal error = %v", err)
+			}
+
+			var c2 Checkout
+			src2, err := ordered.DecodeJSON(out)
+			if err != nil {
+				t.Fatalf("ordered.DecodeJSON round-trip error = %v", err)
+			}
+			if err := ordered.Unmarshal(src2, &c2); err != nil {
+				t.Fatalf("ordered.Unmarshal round-trip error = %v", err)
+			}
+
+			if diff := cmp.Diff(c, c2, cmp.Comparer(ordered.EqualSA)); diff != "" {
+				t.Errorf("Checkout JSON round-trip diff (-orig +new):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCheckoutInterpolationNoOp(t *testing.T) {
+	t.Parallel()
+
+	c := Checkout{Skip: ptr(true)}
+	tf := envInterpolator{
+		env: interpolate.NewMapEnv(map[string]string{"FOO": "bar"}),
+	}
+	if err := c.interpolate(tf); err != nil {
+		t.Fatalf("Checkout.interpolate error = %v", err)
+	}
+	want := Checkout{Skip: ptr(true)}
+	if diff := cmp.Diff(want, c); diff != "" {
+		t.Errorf("Checkout after no-op interpolation (-want +got):\n%s", diff)
+	}
+}
+
+func TestCheckoutMergeFrom(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		child  *Checkout
+		parent *Checkout
+		want   *Checkout
+	}{
+		{
+			name:   "both nil skip",
+			child:  &Checkout{},
+			parent: &Checkout{},
+			want:   &Checkout{},
+		},
+		{
+			name:   "parent only skip",
+			child:  &Checkout{},
+			parent: &Checkout{Skip: ptr(true)},
+			want:   &Checkout{Skip: ptr(true)},
+		},
+		{
+			name:   "child only skip",
+			child:  &Checkout{Skip: ptr(false)},
+			parent: &Checkout{},
+			want:   &Checkout{Skip: ptr(false)},
+		},
+		{
+			name:   "both same",
+			child:  &Checkout{Skip: ptr(true)},
+			parent: &Checkout{Skip: ptr(true)},
+			want:   &Checkout{Skip: ptr(true)},
+		},
+		{
+			name:   "child false beats parent true",
+			child:  &Checkout{Skip: ptr(false)},
+			parent: &Checkout{Skip: ptr(true)},
+			want:   &Checkout{Skip: ptr(false)},
+		},
+		{
+			name:   "child true beats parent false",
+			child:  &Checkout{Skip: ptr(true)},
+			parent: &Checkout{Skip: ptr(false)},
+			want:   &Checkout{Skip: ptr(true)},
+		},
+		{
+			name:   "child inherits parent false",
+			child:  &Checkout{},
+			parent: &Checkout{Skip: ptr(false)},
+			want:   &Checkout{Skip: ptr(false)},
+		},
+		{
+			name: "remaining fields disjoint",
+			child: &Checkout{
+				RemainingFields: map[string]any{"submodules": true},
+			},
+			parent: &Checkout{
+				RemainingFields: map[string]any{"depth": 1},
+			},
+			want: &Checkout{
+				RemainingFields: map[string]any{"submodules": true, "depth": 1},
+			},
+		},
+		{
+			name: "remaining fields scalar collision child wins",
+			child: &Checkout{
+				RemainingFields: map[string]any{"depth": 5},
+			},
+			parent: &Checkout{
+				RemainingFields: map[string]any{"depth": 1},
+			},
+			want: &Checkout{
+				RemainingFields: map[string]any{"depth": 5},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tc.child.mergeFrom(tc.parent)
+			if diff := cmp.Diff(tc.want, tc.child, cmp.Comparer(ordered.EqualSA)); diff != "" {
+				t.Errorf("mergeFrom result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/checkout_test.go
+++ b/checkout_test.go
@@ -15,10 +15,16 @@ import (
 func TestCheckoutMarshalYAML(t *testing.T) {
 	t.Parallel()
 
+	// `want` covers single-key outputs where YAML emission is deterministic.
+	// `wantParts` covers multi-key outputs where the inline-map iteration
+	// order isn't guaranteed by yaml.v3; we assert each line is present
+	// rather than baking a specific ordering into the test.
 	cases := []struct {
-		name string
-		c    Checkout
-		want string
+		name      string
+		c         Checkout
+		want      string
+		wantParts []string
+		notWant   []string
 	}{
 		{
 			name: "empty",
@@ -46,9 +52,9 @@ func TestCheckoutMarshalYAML(t *testing.T) {
 			want: "submodules: false\n",
 		},
 		{
-			name: "skip and submodules",
-			c:    Checkout{Skip: ptr(false), Submodules: ptr(true)},
-			want: "skip: false\nsubmodules: true\n",
+			name:      "skip and submodules",
+			c:         Checkout{Skip: ptr(false), Submodules: ptr(true)},
+			wantParts: []string{"skip: false", "submodules: true"},
 		},
 		{
 			name: "with remaining fields",
@@ -56,7 +62,15 @@ func TestCheckoutMarshalYAML(t *testing.T) {
 				Skip:            ptr(true),
 				RemainingFields: map[string]any{"depth": 1},
 			},
-			want: "skip: true\ndepth: 1\n",
+			wantParts: []string{"skip: true", "depth: 1"},
+		},
+		{
+			name: "remaining fields only",
+			c: Checkout{
+				RemainingFields: map[string]any{"depth": 1},
+			},
+			wantParts: []string{"depth: 1"},
+			notWant:   []string{"skip", "submodules"},
 		},
 	}
 
@@ -68,8 +82,19 @@ func TestCheckoutMarshalYAML(t *testing.T) {
 			if err != nil {
 				t.Fatalf("yaml.Marshal(%#v) error = %v", tc.c, err)
 			}
-			if string(got) != tc.want {
-				t.Errorf("yaml.Marshal(%#v) = %q, want %q", tc.c, got, tc.want)
+			out := string(got)
+			if tc.want != "" && out != tc.want {
+				t.Errorf("yaml.Marshal(%#v) = %q, want %q", tc.c, out, tc.want)
+			}
+			for _, part := range tc.wantParts {
+				if !strings.Contains(out, part) {
+					t.Errorf("yaml.Marshal(%#v) missing %q:\n%s", tc.c, part, out)
+				}
+			}
+			for _, no := range tc.notWant {
+				if strings.Contains(out, no) {
+					t.Errorf("yaml.Marshal(%#v) unexpectedly contained %q:\n%s", tc.c, no, out)
+				}
 			}
 		})
 	}
@@ -372,6 +397,54 @@ steps:
 	if step.Checkout.Skip == nil || *step.Checkout.Skip != true {
 		t.Errorf("step.Checkout.Skip = %v, want ptr(true)", step.Checkout.Skip)
 	}
+
+	// Mutating one side must not leak into the other; the unmarshaler should
+	// materialise independent Checkout values per alias expansion.
+	*step.Checkout.Skip = false
+	if *p.Checkout.Skip != true {
+		t.Errorf("mutating step.Checkout.Skip leaked into p.Checkout.Skip = %v", *p.Checkout.Skip)
+	}
+}
+
+func TestPipelineCheckoutOmittedWhenNil(t *testing.T) {
+	t.Parallel()
+
+	p, err := Parse(strings.NewReader("steps:\n  - command: echo hello\n"))
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+	if p.Checkout != nil {
+		t.Errorf("p.Checkout = %+v, want nil", p.Checkout)
+	}
+
+	b, err := yaml.Marshal(&Pipeline{Steps: Steps{}})
+	if err != nil {
+		t.Fatalf("yaml.Marshal error = %v", err)
+	}
+	if strings.Contains(string(b), "checkout") {
+		t.Errorf("yaml.Marshal of Pipeline with nil Checkout emitted \"checkout\":\n%s", b)
+	}
+}
+
+func TestCommandStepCheckoutOmittedWhenNil(t *testing.T) {
+	t.Parallel()
+
+	bareJSON, err := json.Marshal(&CommandStep{})
+	if err != nil {
+		t.Fatalf("json.Marshal bare error = %v", err)
+	}
+	if strings.Contains(string(bareJSON), "checkout") {
+		t.Errorf("bare CommandStep JSON emitted \"checkout\":\n%s", bareJSON)
+	}
+
+	withCheckoutJSON, err := json.Marshal(&CommandStep{Checkout: &Checkout{Skip: ptr(true)}})
+	if err != nil {
+		t.Fatalf("json.Marshal with checkout error = %v", err)
+	}
+	want := `"checkout":{"skip":true}`
+	if !strings.Contains(string(withCheckoutJSON), want) {
+		t.Errorf("CommandStep JSON missing %q:\n%s", want, withCheckoutJSON)
+	}
 }
 
 func TestCheckoutRoundTripYAML(t *testing.T) {
@@ -641,12 +714,13 @@ func TestCheckoutMergeFrom(t *testing.T) {
 	}
 }
 
-// Extra fields on a checkout block survive json.Unmarshal when routed via
+// Unknown fields on a checkout block survive json.Unmarshal when routed via
 // CommandStep.UnmarshalJSON, which decodes through ordered.Unmarshal and
-// honors the inline tag. Direct json.Unmarshal into a Checkout does not
-// preserve them (Checkout has no custom UnmarshalJSON, matching the
-// Cache/Secret pattern), so consumers should always go through the parent
-// step's unmarshaler.
+// honors the inline tag. Direct json.Unmarshal into a Checkout drops the
+// inline extras (Checkout has no custom UnmarshalJSON, matching the
+// Cache/Secret pattern); typed Skip and Submodules still unmarshal in either
+// path. Consumers wanting forward-compat for unknown fields should always go
+// through the parent step's unmarshaler.
 func TestCommandStepCheckoutJSONUnmarshalExtraFields(t *testing.T) {
 	t.Parallel()
 

--- a/checkout_test.go
+++ b/checkout_test.go
@@ -497,7 +497,7 @@ func TestCheckoutRoundTripJSON(t *testing.T) {
 	}
 }
 
-func TestCheckoutInterpolationNoOp(t *testing.T) {
+func TestCheckoutInterpolationPreservesTypedFields(t *testing.T) {
 	t.Parallel()
 
 	c := Checkout{Skip: ptr(true), Submodules: ptr(false)}
@@ -509,7 +509,28 @@ func TestCheckoutInterpolationNoOp(t *testing.T) {
 	}
 	want := Checkout{Skip: ptr(true), Submodules: ptr(false)}
 	if diff := cmp.Diff(want, c); diff != "" {
-		t.Errorf("Checkout after no-op interpolation (-want +got):\n%s", diff)
+		t.Errorf("Checkout after interpolation (-want +got):\n%s", diff)
+	}
+}
+
+func TestCheckoutInterpolationOfRemainingFields(t *testing.T) {
+	t.Parallel()
+
+	c := Checkout{
+		Skip: ptr(true),
+		RemainingFields: map[string]any{
+			"depth_flag": "--depth=${DEPTH}",
+		},
+	}
+	tf := envInterpolator{
+		env: interpolate.NewMapEnv(map[string]string{"DEPTH": "5"}),
+	}
+	if err := c.interpolate(tf); err != nil {
+		t.Fatalf("Checkout.interpolate error = %v", err)
+	}
+	want := map[string]any{"depth_flag": "--depth=5"}
+	if diff := cmp.Diff(want, c.RemainingFields); diff != "" {
+		t.Errorf("Checkout.RemainingFields after interpolation (-want +got):\n%s", diff)
 	}
 }
 

--- a/checkout_test.go
+++ b/checkout_test.go
@@ -406,6 +406,36 @@ steps:
 	}
 }
 
+func TestCheckoutUnmarshalAliasesStepVsStep(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `_anchors:
+  base: &base
+    skip: true
+steps:
+  - command: echo a
+    checkout: *base
+  - command: echo b
+    checkout: *base
+`
+
+	p, err := Parse(strings.NewReader(yamlData))
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+
+	stepA := p.Steps[0].(*CommandStep)
+	stepB := p.Steps[1].(*CommandStep)
+	if stepA.Checkout == nil || stepB.Checkout == nil {
+		t.Fatalf("step checkouts = %v, %v, want both non-nil", stepA.Checkout, stepB.Checkout)
+	}
+
+	*stepA.Checkout.Skip = false
+	if *stepB.Checkout.Skip != true {
+		t.Errorf("mutating stepA leaked into stepB.Checkout.Skip = %v", *stepB.Checkout.Skip)
+	}
+}
+
 func TestPipelineCheckoutOmittedWhenNil(t *testing.T) {
 	t.Parallel()
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -13,9 +13,10 @@ import (
 //
 // Standard caveats apply - see the package comment.
 type Pipeline struct {
-	Steps   Steps          `yaml:"steps"`
-	Env     *ordered.MapSS `yaml:"env,omitempty"`
-	Secrets Secrets        `yaml:"secrets,omitempty"`
+	Steps    Steps          `yaml:"steps"`
+	Env      *ordered.MapSS `yaml:"env,omitempty"`
+	Secrets  Secrets        `yaml:"secrets,omitempty"`
+	Checkout *Checkout      `yaml:"checkout,omitempty"`
 
 	// RemainingFields stores any other top-level mapping items so they at least
 	// survive an unmarshal-marshal round-trip.
@@ -102,6 +103,12 @@ func (p *Pipeline) Interpolate(interpolationEnv InterpolationEnv, preferRuntimeE
 	// variable interpolation on strings. Interpolation is performed in-place.
 	if err := interpolateSlice(tf, p.Steps); err != nil {
 		return err
+	}
+
+	if p.Checkout != nil {
+		if err := p.Checkout.interpolate(tf); err != nil {
+			return err
+		}
 	}
 
 	return interpolateMap(tf, p.RemainingFields)

--- a/signature/pipeline_invariants.go
+++ b/signature/pipeline_invariants.go
@@ -42,6 +42,11 @@ func (c *commandStepWithInvariants) SignedFields() (map[string]any, error) {
 		object["secrets"] = EmptyToNilSlice(c.Secrets)
 	}
 
+	// Only include checkout if non-empty to maintain backward compatibility
+	if !c.Checkout.IsEmpty() {
+		object["checkout"] = c.Checkout
+	}
+
 	// Step env overrides pipeline and build env:
 	// https://buildkite.com/docs/tutorials/pipeline-upgrade#what-is-the-yaml-steps-editor-compatibility-issues
 	// (Beware of inconsistent docs written in the time of legacy steps.)
@@ -74,6 +79,11 @@ func (c *commandStepWithInvariants) ValuesForFields(fields []string) (map[string
 		required["secrets"] = struct{}{}
 	}
 
+	// Only require checkout field if step has checkout
+	if !c.Checkout.IsEmpty() {
+		required["checkout"] = struct{}{}
+	}
+
 	out := make(map[string]any, len(fields))
 	for _, f := range fields {
 		delete(required, f)
@@ -96,6 +106,9 @@ func (c *commandStepWithInvariants) ValuesForFields(fields []string) (map[string
 
 		case "secrets":
 			out["secrets"] = EmptyToNilSlice(c.Secrets)
+
+		case "checkout":
+			out["checkout"] = EmptyToNilPtr(c.Checkout)
 
 		default:
 			if name, has := strings.CutPrefix(f, EnvNamespacePrefix); has {

--- a/signature/pipeline_invariants.go
+++ b/signature/pipeline_invariants.go
@@ -42,9 +42,11 @@ func (c *commandStepWithInvariants) SignedFields() (map[string]any, error) {
 		object["secrets"] = EmptyToNilSlice(c.Secrets)
 	}
 
-	// Only include checkout if non-empty to maintain backward compatibility
+	// Include checkout only when non-empty, so signatures produced against
+	// steps with no checkout config keep the legacy field set. Note this is
+	// not symmetric with verification: see ValuesForFields below.
 	if !c.Checkout.IsEmpty() {
-		object["checkout"] = c.Checkout
+		object["checkout"] = EmptyToNilPtr(c.Checkout)
 	}
 
 	// Step env overrides pipeline and build env:
@@ -79,7 +81,13 @@ func (c *commandStepWithInvariants) ValuesForFields(fields []string) (map[string
 		required["secrets"] = struct{}{}
 	}
 
-	// Only require checkout field if step has checkout
+	// Require checkout when the step has any checkout config, so an attacker
+	// cannot strip "checkout" from signed_fields and ship modified checkout
+	// settings. The cost is that signatures produced before checkout was
+	// signed will fail to verify if the step now carries any Checkout data
+	// (e.g. a step that only sets `submodules`), even when nothing was
+	// modified. Operators rotating to this verifier should re-sign such
+	// pipelines.
 	if !c.Checkout.IsEmpty() {
 		required["checkout"] = struct{}{}
 	}

--- a/signature/pipeline_invariants_test.go
+++ b/signature/pipeline_invariants_test.go
@@ -1,6 +1,7 @@
 package signature
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/buildkite/go-pipeline"
@@ -157,5 +158,115 @@ func TestCommandStepWithInvariants_ValuesForFields_NoSecretsNoSecretsField(t *te
 
 	if diff := cmp.Diff(values, wantValues); diff != "" {
 		t.Errorf("step.ValuesForFields(%v) diff (-got +want):\n%s", fields, diff)
+	}
+}
+
+func ptr[T any](x T) *T { return &x }
+
+func TestCommandStepWithInvariants_SignedFields_WithCheckout(t *testing.T) {
+	t.Parallel()
+
+	checkout := &pipeline.Checkout{Skip: ptr(true)}
+	step := commandStepWithInvariants{
+		CommandStep: pipeline.CommandStep{
+			Command:  "echo hello",
+			Env:      map[string]string{"FOO": "bar"},
+			Plugins:  pipeline.Plugins{},
+			Checkout: checkout,
+		},
+		RepositoryURL: "https://github.com/example/repo",
+	}
+
+	fields, err := step.SignedFields()
+	if err != nil {
+		t.Fatalf("step.SignedFields() error = %v", err)
+	}
+
+	if diff := cmp.Diff(fields["checkout"], checkout); diff != "" {
+		t.Errorf("step.SignedFields()[\"checkout\"] diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestCommandStepWithInvariants_SignedFields_EmptyCheckout(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		checkout *pipeline.Checkout
+	}{
+		{name: "nil", checkout: nil},
+		{name: "zero value", checkout: &pipeline.Checkout{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			step := commandStepWithInvariants{
+				CommandStep: pipeline.CommandStep{
+					Command:  "echo hello",
+					Checkout: tc.checkout,
+				},
+				RepositoryURL: "https://github.com/example/repo",
+			}
+
+			fields, err := step.SignedFields()
+			if err != nil {
+				t.Fatalf("step.SignedFields() error = %v", err)
+			}
+
+			// checkout must be absent when empty, for backward compatibility
+			// with signatures produced before checkout was signed.
+			if _, has := fields["checkout"]; has {
+				t.Errorf("step.SignedFields()[\"checkout\"] = %v, want absent", fields["checkout"])
+			}
+		})
+	}
+}
+
+func TestCommandStepWithInvariants_ValuesForFields_WithCheckout(t *testing.T) {
+	t.Parallel()
+
+	checkout := &pipeline.Checkout{Skip: ptr(true)}
+	step := commandStepWithInvariants{
+		CommandStep: pipeline.CommandStep{
+			Command:  "echo hello",
+			Plugins:  pipeline.Plugins{},
+			Checkout: checkout,
+		},
+		RepositoryURL: "https://github.com/example/repo",
+	}
+
+	fields := []string{"command", "env", "plugins", "matrix", "repository_url", "checkout"}
+	values, err := step.ValuesForFields(fields)
+	if err != nil {
+		t.Fatalf("step.ValuesForFields() error = %v", err)
+	}
+
+	if diff := cmp.Diff(values["checkout"], checkout); diff != "" {
+		t.Errorf("step.ValuesForFields()[\"checkout\"] diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestCommandStepWithInvariants_ValuesForFields_MissingCheckoutField(t *testing.T) {
+	t.Parallel()
+
+	step := commandStepWithInvariants{
+		CommandStep: pipeline.CommandStep{
+			Command:  "echo hello",
+			Plugins:  pipeline.Plugins{},
+			Checkout: &pipeline.Checkout{Skip: ptr(true)},
+		},
+		RepositoryURL: "https://github.com/example/repo",
+	}
+
+	// Step has checkout but verifier didn't ask for it - should fail.
+	fields := []string{"command", "env", "plugins", "matrix", "repository_url"}
+	_, err := step.ValuesForFields(fields)
+	if err == nil {
+		t.Fatalf("step.ValuesForFields(%v) error = nil, want error mentioning checkout", fields)
+	}
+	if !strings.Contains(err.Error(), "checkout") {
+		t.Errorf("error %q does not mention checkout", err.Error())
 	}
 }

--- a/signature/sign_test.go
+++ b/signature/sign_test.go
@@ -512,6 +512,172 @@ func TestSignVerifySecrets(t *testing.T) {
 	}
 }
 
+func TestSignVerifyCheckout(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		step *pipeline.CommandStep
+	}{
+		{
+			name: "skip true",
+			step: &pipeline.CommandStep{
+				Command:  "llamas",
+				Checkout: &pipeline.Checkout{Skip: ptr(true)},
+			},
+		},
+		{
+			name: "skip false",
+			step: &pipeline.CommandStep{
+				Command:  "llamas",
+				Checkout: &pipeline.Checkout{Skip: ptr(false)},
+			},
+		},
+		{
+			name: "submodules only",
+			step: &pipeline.CommandStep{
+				Command:  "llamas",
+				Checkout: &pipeline.Checkout{Submodules: ptr(true)},
+			},
+		},
+		{
+			name: "skip and submodules",
+			step: &pipeline.CommandStep{
+				Command:  "llamas",
+				Checkout: &pipeline.Checkout{Skip: ptr(false), Submodules: ptr(true)},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			keyStr, keyAlg := "alpacas", jwa.HS256
+			signer, verifier, err := jwkutil.NewSymmetricKeyPairFromString(keyID, keyStr, keyAlg)
+			if err != nil {
+				t.Fatalf("jwkutil.NewSymmetricKeyPairFromString(%q, %q, %q) error = %v", keyID, keyStr, keyAlg, err)
+			}
+
+			key, ok := signer.Key(0)
+			if !ok {
+				t.Fatalf("signer.Key(0) = _, false, want true")
+			}
+
+			toSign := &commandStepWithInvariants{
+				CommandStep:   *tc.step,
+				RepositoryURL: fakeRepositoryURL,
+			}
+			toVerify := &commandStepWithInvariants{
+				CommandStep:   *tc.step,
+				RepositoryURL: fakeRepositoryURL,
+			}
+
+			sig, err := Sign(ctx, key, toSign)
+			if err != nil {
+				t.Fatalf("Sign(ctx, key, %v) error = %v", toSign, err)
+			}
+
+			if !slices.Contains(sig.SignedFields, "checkout") {
+				t.Errorf("sig.SignedFields = %v, want it to contain %q", sig.SignedFields, "checkout")
+			}
+
+			if err := Verify(ctx, sig, verifier, toVerify); err != nil {
+				t.Errorf("Verify(ctx, %v, verifier, %v) = %v", sig, toVerify, err)
+			}
+		})
+	}
+}
+
+// TestSignVerifyCheckoutTamperDetection asserts that swapping checkout values
+// between sign and verify fails verification, so the signer can't be ignored
+// at the agent.
+func TestSignVerifyCheckoutTamperDetection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	signStep := &pipeline.CommandStep{
+		Command:  "llamas",
+		Checkout: &pipeline.Checkout{Skip: ptr(true)},
+	}
+	verifyStep := &pipeline.CommandStep{
+		Command:  "llamas",
+		Checkout: &pipeline.Checkout{Skip: ptr(false)},
+	}
+
+	keyStr, keyAlg := "alpacas", jwa.HS256
+	signer, verifier, err := jwkutil.NewSymmetricKeyPairFromString(keyID, keyStr, keyAlg)
+	if err != nil {
+		t.Fatalf("jwkutil.NewSymmetricKeyPairFromString(%q, %q, %q) error = %v", keyID, keyStr, keyAlg, err)
+	}
+
+	key, ok := signer.Key(0)
+	if !ok {
+		t.Fatalf("signer.Key(0) = _, false, want true")
+	}
+
+	sig, err := Sign(ctx, key, &commandStepWithInvariants{CommandStep: *signStep, RepositoryURL: fakeRepositoryURL})
+	if err != nil {
+		t.Fatalf("Sign error = %v", err)
+	}
+
+	err = Verify(ctx, sig, verifier, &commandStepWithInvariants{CommandStep: *verifyStep, RepositoryURL: fakeRepositoryURL})
+	if err == nil {
+		t.Fatalf("Verify error = nil, want non-nil for tampered checkout")
+	}
+}
+
+// TestVerifyLegacySignatureWithCheckoutFails documents the contract that an
+// "old-format" signature (one whose signed_fields list does not contain
+// "checkout") cannot verify a step that now carries any non-empty Checkout
+// data. Pre-PR-#73 signers on feat/git-checkout-features could produce such
+// signatures (PR #74 added Submodules without signing it). The new verifier
+// requires "checkout" to be in signed_fields whenever the step's Checkout is
+// non-empty, so those pipelines must be re-signed.
+func TestVerifyLegacySignatureWithCheckoutFails(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Sign with no checkout (the pre-#73 state).
+	signStep := &pipeline.CommandStep{Command: "llamas"}
+	// Verify with the same step but carrying checkout data (e.g. a pipeline
+	// that always had `submodules: true` but was signed before checkout was
+	// part of the signed payload).
+	verifyStep := &pipeline.CommandStep{
+		Command:  "llamas",
+		Checkout: &pipeline.Checkout{Submodules: ptr(true)},
+	}
+
+	keyStr, keyAlg := "alpacas", jwa.HS256
+	signer, verifier, err := jwkutil.NewSymmetricKeyPairFromString(keyID, keyStr, keyAlg)
+	if err != nil {
+		t.Fatalf("jwkutil.NewSymmetricKeyPairFromString(%q, %q, %q) error = %v", keyID, keyStr, keyAlg, err)
+	}
+
+	key, ok := signer.Key(0)
+	if !ok {
+		t.Fatalf("signer.Key(0) = _, false, want true")
+	}
+
+	sig, err := Sign(ctx, key, &commandStepWithInvariants{CommandStep: *signStep, RepositoryURL: fakeRepositoryURL})
+	if err != nil {
+		t.Fatalf("Sign error = %v", err)
+	}
+
+	if slices.Contains(sig.SignedFields, "checkout") {
+		t.Fatalf("sig.SignedFields = %v, want it to NOT contain %q (sign step has no checkout)", sig.SignedFields, "checkout")
+	}
+
+	err = Verify(ctx, sig, verifier, &commandStepWithInvariants{CommandStep: *verifyStep, RepositoryURL: fakeRepositoryURL})
+	if err == nil {
+		t.Fatalf("Verify error = nil, want error citing missing 'checkout' field")
+	}
+	if !strings.Contains(err.Error(), "checkout") {
+		t.Errorf("Verify error = %q, want it to mention 'checkout'", err.Error())
+	}
+}
+
 func TestSignVerifyEnv(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -700,6 +866,26 @@ func TestSignVerify_NilVsEmpty(t *testing.T) {
 			name:       "matrix sign empty verify empty",
 			stepSign:   &pipeline.CommandStep{Command: "llamas", Matrix: &pipeline.Matrix{}},
 			stepVerify: &pipeline.CommandStep{Command: "llamas", Matrix: &pipeline.Matrix{}},
+		},
+		{
+			name:       "checkout sign nil verify nil",
+			stepSign:   &pipeline.CommandStep{Command: "llamas", Checkout: nil},
+			stepVerify: &pipeline.CommandStep{Command: "llamas", Checkout: nil},
+		},
+		{
+			name:       "checkout sign nil verify empty",
+			stepSign:   &pipeline.CommandStep{Command: "llamas", Checkout: nil},
+			stepVerify: &pipeline.CommandStep{Command: "llamas", Checkout: &pipeline.Checkout{}},
+		},
+		{
+			name:       "checkout sign empty verify nil",
+			stepSign:   &pipeline.CommandStep{Command: "llamas", Checkout: &pipeline.Checkout{}},
+			stepVerify: &pipeline.CommandStep{Command: "llamas", Checkout: nil},
+		},
+		{
+			name:       "checkout sign empty verify empty",
+			stepSign:   &pipeline.CommandStep{Command: "llamas", Checkout: &pipeline.Checkout{}},
+			stepVerify: &pipeline.CommandStep{Command: "llamas", Checkout: &pipeline.Checkout{}},
 		},
 	}
 

--- a/signature/sign_test.go
+++ b/signature/sign_test.go
@@ -628,13 +628,9 @@ func TestSignVerifyCheckoutTamperDetection(t *testing.T) {
 	}
 }
 
-// TestVerifyLegacySignatureWithCheckoutFails documents the contract that an
-// "old-format" signature (one whose signed_fields list does not contain
-// "checkout") cannot verify a step that now carries any non-empty Checkout
-// data. Pre-PR-#73 signers on feat/git-checkout-features could produce such
-// signatures (PR #74 added Submodules without signing it). The new verifier
-// requires "checkout" to be in signed_fields whenever the step's Checkout is
-// non-empty, so those pipelines must be re-signed.
+// TestVerifyLegacySignatureWithCheckoutFails asserts that a signature whose
+// signed_fields omits "checkout" fails to verify a step that now carries
+// non-empty Checkout data.
 func TestVerifyLegacySignatureWithCheckoutFails(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/step_command.go
+++ b/step_command.go
@@ -37,6 +37,7 @@ type CommandStep struct {
 	Signature *Signature        `yaml:"signature,omitempty"`
 	Matrix    *Matrix           `yaml:"matrix,omitempty"`
 	Cache     *Cache            `yaml:"cache,omitempty"`
+	Checkout  *Checkout         `yaml:"checkout,omitempty"`
 
 	// RemainingFields stores any other top-level mapping items so they at least
 	// survive an unmarshal-marshal round-trip.
@@ -111,6 +112,11 @@ func (c *CommandStep) interpolate(tf stringTransformer) error {
 	if err := interpolateSlice(tf, c.Secrets); err != nil {
 		return fmt.Errorf("interpolating secrets: %w", err)
 	}
+	if c.Checkout != nil {
+		if err := c.Checkout.interpolate(tf); err != nil {
+			return fmt.Errorf("interpolating checkout: %w", err)
+		}
+	}
 
 	switch tf.(type) {
 	case envInterpolator:
@@ -147,6 +153,20 @@ func (c *CommandStep) interpolate(tf stringTransformer) error {
 // Step-level secrets take precedence over pipeline-level secrets for deduplication.
 func (c *CommandStep) MergeSecretsFromPipeline(pipelineSecrets Secrets) {
 	c.Secrets = pipelineSecrets.MergeWith(c.Secrets)
+}
+
+// MergeCheckoutFromPipeline merges pipeline-level checkout config into this
+// step's checkout. Step-level values take precedence per leaf. An empty parent
+// is treated as no-op so callers don't materialise empty `checkout: {}` on
+// steps that didn't have one.
+func (c *CommandStep) MergeCheckoutFromPipeline(pipelineCheckout *Checkout) {
+	if pipelineCheckout.IsEmpty() {
+		return
+	}
+	if c.Checkout == nil {
+		c.Checkout = &Checkout{}
+	}
+	c.Checkout.mergeFrom(pipelineCheckout)
 }
 
 func (CommandStep) stepTag() {}

--- a/step_command.go
+++ b/step_command.go
@@ -113,7 +113,7 @@ func (c *CommandStep) interpolate(tf stringTransformer) error {
 		return fmt.Errorf("interpolating secrets: %w", err)
 	}
 	if c.Cache != nil {
-		if err := c.Cache.interpolate(tf); err != nil {
+		if _, err := interpolateAny(tf, c.Cache); err != nil {
 			return fmt.Errorf("interpolating cache: %w", err)
 		}
 	}

--- a/step_command.go
+++ b/step_command.go
@@ -161,9 +161,12 @@ func (c *CommandStep) MergeSecretsFromPipeline(pipelineSecrets Secrets) {
 }
 
 // MergeCheckoutFromPipeline merges pipeline-level checkout config into this
-// step's checkout. Step-level values take precedence per leaf. An empty parent
-// is treated as no-op so callers don't materialise empty `checkout: {}` on
-// steps that didn't have one.
+// step's checkout. Step-level values take precedence per leaf; an empty
+// parent is a no-op.
+//
+// The receiver's Checkout is mutated in place, so callers that share a
+// *Checkout across steps (e.g. via programmatic construction) must copy
+// first. The parse path materialises an independent Checkout per step.
 func (c *CommandStep) MergeCheckoutFromPipeline(pipelineCheckout *Checkout) {
 	if pipelineCheckout.IsEmpty() {
 		return

--- a/step_command_checkout_test.go
+++ b/step_command_checkout_test.go
@@ -387,20 +387,25 @@ steps:
 	}
 }
 
-func TestPipelineCheckoutInterpolationDoesNotMutateSkip(t *testing.T) {
+func TestPipelineCheckoutInterpolation(t *testing.T) {
 	t.Parallel()
 
 	src := `checkout:
   skip: true
+  pipeline_flag: "--pipeline=${PIPELINE_VAR}"
 steps:
   - command: echo hello
     checkout:
       skip: false
+      step_flag: "--step=${STEP_VAR}"
 `
 
 	p := parseCheckoutPipeline(t, src)
 
-	runtimeEnv := env.New(env.FromMap(map[string]string{"FOO": "bar"}))
+	runtimeEnv := env.New(env.FromMap(map[string]string{
+		"PIPELINE_VAR": "p",
+		"STEP_VAR":     "s",
+	}))
 	if err := p.Interpolate(runtimeEnv, false); err != nil {
 		t.Fatalf("p.Interpolate error = %v", err)
 	}
@@ -408,9 +413,16 @@ steps:
 	if p.Checkout.Skip == nil || *p.Checkout.Skip != true {
 		t.Errorf("p.Checkout.Skip after interpolate = %v, want ptr(true)", p.Checkout.Skip)
 	}
+	if got := p.Checkout.RemainingFields["pipeline_flag"]; got != "--pipeline=p" {
+		t.Errorf("p.Checkout.RemainingFields[pipeline_flag] = %v, want %q", got, "--pipeline=p")
+	}
+
 	step := p.Steps[0].(*CommandStep)
 	if step.Checkout.Skip == nil || *step.Checkout.Skip != false {
 		t.Errorf("step.Checkout.Skip after interpolate = %v, want ptr(false)", step.Checkout.Skip)
+	}
+	if got := step.Checkout.RemainingFields["step_flag"]; got != "--step=s" {
+		t.Errorf("step.Checkout.RemainingFields[step_flag] = %v, want %q", got, "--step=s")
 	}
 }
 

--- a/step_command_checkout_test.go
+++ b/step_command_checkout_test.go
@@ -350,8 +350,8 @@ steps:
 	}
 }
 
-// parseCheckoutPipeline parses a pipeline at the public API level and asserts
-// the basic structure (one or more *CommandStep) shared by several tests below.
+// parseCheckoutPipeline parses src via the public Parse API and fails the
+// test on error.
 func parseCheckoutPipeline(t *testing.T, src string) *Pipeline {
 	t.Helper()
 	p, err := Parse(strings.NewReader(src))

--- a/step_command_checkout_test.go
+++ b/step_command_checkout_test.go
@@ -1,0 +1,480 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/go-pipeline/internal/env"
+	"github.com/buildkite/go-pipeline/ordered"
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCommandStepWithCheckoutYAML(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+command: echo "hello"
+checkout:
+  skip: false
+`
+
+	var step CommandStep
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+	if err := ordered.Unmarshal(&node, &step); err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	if step.Checkout == nil {
+		t.Fatalf("step.Checkout = nil, want non-nil")
+	}
+	if step.Checkout.Skip == nil || *step.Checkout.Skip != false {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(false)", step.Checkout.Skip)
+	}
+}
+
+func TestCommandStepWithCheckoutJSON(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"command":"echo hello","checkout":{"skip":true}}`)
+
+	got := new(CommandStep)
+	if err := got.UnmarshalJSON(input); err != nil {
+		t.Fatalf("CommandStep.UnmarshalJSON() = %v", err)
+	}
+
+	if got.Checkout == nil {
+		t.Fatalf("step.Checkout = nil, want non-nil")
+	}
+	if got.Checkout.Skip == nil || *got.Checkout.Skip != true {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(true)", got.Checkout.Skip)
+	}
+}
+
+func TestCommandStepCheckoutFalseSurvivesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+command: echo hello
+checkout:
+  skip: false
+`
+
+	var step CommandStep
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+	if err := ordered.Unmarshal(&node, &step); err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	out, err := yaml.Marshal(step)
+	if err != nil {
+		t.Fatalf("yaml.Marshal error = %v", err)
+	}
+
+	if !strings.Contains(string(out), "skip: false") {
+		t.Errorf("YAML output missing 'skip: false':\n%s", out)
+	}
+}
+
+func TestCommandStepCheckoutRejectsBool(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+command: echo hello
+checkout: false
+`
+
+	var step CommandStep
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err := ordered.Unmarshal(&node, &step)
+	if err == nil {
+		t.Fatalf("ordered.Unmarshal() error = nil, want error mentioning checkout.skip")
+	}
+	if !strings.Contains(err.Error(), "checkout.skip") {
+		t.Errorf("error %q does not mention checkout.skip", err.Error())
+	}
+}
+
+func TestPipelineCheckoutRejectsBool(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{
+			name: "false",
+			in: `checkout: false
+steps:
+  - command: echo hello
+`,
+		},
+		{
+			name: "true",
+			in: `checkout: true
+steps:
+  - command: echo hello
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Parse(strings.NewReader(tc.in))
+			if err == nil {
+				t.Fatalf("Parse() error = nil, want error mentioning checkout.skip")
+			}
+			if !strings.Contains(err.Error(), "checkout.skip") {
+				t.Errorf("error %q does not mention checkout.skip", err.Error())
+			}
+		})
+	}
+}
+
+func TestMergeCheckoutFromPipelineNilPipeline(t *testing.T) {
+	t.Parallel()
+
+	step := &CommandStep{Checkout: &Checkout{Skip: ptr(true)}}
+	step.MergeCheckoutFromPipeline(nil)
+
+	if step.Checkout == nil || step.Checkout.Skip == nil || *step.Checkout.Skip != true {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(true) preserved", step.Checkout)
+	}
+}
+
+func TestMergeCheckoutFromPipelineNilStep(t *testing.T) {
+	t.Parallel()
+
+	pipelineCheckout := &Checkout{
+		Skip: ptr(true),
+		RemainingFields: map[string]any{
+			"depth": 1,
+		},
+	}
+	step := &CommandStep{}
+	step.MergeCheckoutFromPipeline(pipelineCheckout)
+
+	if step.Checkout == nil {
+		t.Fatalf("step.Checkout = nil, want copy of pipeline checkout")
+	}
+	if step.Checkout.Skip == nil || *step.Checkout.Skip != true {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(true)", step.Checkout.Skip)
+	}
+
+	// Verify the copy is independent: mutating the step should not affect
+	// the pipeline.
+	*step.Checkout.Skip = false
+	if *pipelineCheckout.Skip != true {
+		t.Errorf("mutating step mutated pipeline; pipelineCheckout.Skip = %v", *pipelineCheckout.Skip)
+	}
+
+	step.Checkout.RemainingFields["depth"] = 99
+	if pipelineCheckout.RemainingFields["depth"] != 1 {
+		t.Errorf("mutating step.RemainingFields mutated pipeline; depth = %v", pipelineCheckout.RemainingFields["depth"])
+	}
+}
+
+func TestPipelineWithCheckoutYAML(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+checkout:
+  skip: false
+steps:
+  - command: echo hello
+    checkout:
+      skip: true
+`
+
+	var p Pipeline
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+	if err := ordered.Unmarshal(&node, &p); err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	if p.Checkout == nil {
+		t.Fatalf("p.Checkout = nil, want non-nil")
+	}
+	if p.Checkout.Skip == nil || *p.Checkout.Skip != false {
+		t.Errorf("p.Checkout.Skip = %v, want ptr(false)", p.Checkout.Skip)
+	}
+
+	if len(p.Steps) != 1 {
+		t.Fatalf("len(p.Steps) = %d, want 1", len(p.Steps))
+	}
+	step, ok := p.Steps[0].(*CommandStep)
+	if !ok {
+		t.Fatalf("p.Steps[0] = %T, want *CommandStep", p.Steps[0])
+	}
+	if step.Checkout == nil || step.Checkout.Skip == nil || *step.Checkout.Skip != true {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(true)", step.Checkout)
+	}
+}
+
+func TestPipelineCheckoutSkipFalseRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `checkout:
+    skip: false
+steps:
+    - command: echo hello
+`
+
+	var p Pipeline
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+	if err := ordered.Unmarshal(&node, &p); err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	out, err := yaml.Marshal(&p)
+	if err != nil {
+		t.Fatalf("yaml.Marshal error = %v", err)
+	}
+
+	if !strings.Contains(string(out), "skip: false") {
+		t.Errorf("Pipeline YAML round-trip lost 'skip: false':\n%s", out)
+	}
+}
+
+func TestPipelineCheckoutMergeAtBothLevels(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `checkout:
+  skip: false
+  depth: 1
+steps:
+  - command: echo hello
+    checkout:
+      skip: true
+  - command: echo bye
+`
+
+	p, err := Parse(strings.NewReader(yamlData))
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+
+	if p.Checkout == nil {
+		t.Fatalf("p.Checkout = nil, want non-nil")
+	}
+	if p.Checkout.Skip == nil || *p.Checkout.Skip != false {
+		t.Errorf("p.Checkout.Skip = %v, want ptr(false)", p.Checkout.Skip)
+	}
+	if got := p.Checkout.RemainingFields["depth"]; got != 1 {
+		t.Errorf("p.Checkout.RemainingFields[depth] = %v, want 1", got)
+	}
+
+	if len(p.Steps) != 2 {
+		t.Fatalf("len(p.Steps) = %d, want 2", len(p.Steps))
+	}
+
+	step1 := p.Steps[0].(*CommandStep)
+	if step1.Checkout == nil || step1.Checkout.Skip == nil || *step1.Checkout.Skip != true {
+		t.Errorf("step1.Checkout.Skip = %v, want ptr(true)", step1.Checkout)
+	}
+
+	step2 := p.Steps[1].(*CommandStep)
+	if step2.Checkout != nil {
+		t.Errorf("step2.Checkout = %v, want nil", step2.Checkout)
+	}
+
+	step2.MergeCheckoutFromPipeline(p.Checkout)
+	if step2.Checkout == nil || step2.Checkout.Skip == nil || *step2.Checkout.Skip != false {
+		t.Errorf("step2.Checkout.Skip after merge = %v, want ptr(false)", step2.Checkout)
+	}
+	if got := step2.Checkout.RemainingFields["depth"]; got != 1 {
+		t.Errorf("step2.Checkout.RemainingFields[depth] after merge = %v, want 1", got)
+	}
+}
+
+// parseCheckoutPipeline parses a pipeline at the public API level and asserts
+// the basic structure (one or more *CommandStep) shared by several tests below.
+func parseCheckoutPipeline(t *testing.T, src string) *Pipeline {
+	t.Helper()
+	p, err := Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+	return p
+}
+
+func TestPipelineCheckoutParseAndMarshalRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	src := `checkout:
+  skip: false
+steps:
+  - command: echo hello
+    checkout:
+      skip: true
+`
+
+	p := parseCheckoutPipeline(t, src)
+
+	// YAML round-trip: marshal, re-parse, compare.
+	yamlOut, err := yaml.Marshal(p)
+	if err != nil {
+		t.Fatalf("yaml.Marshal error = %v", err)
+	}
+	p2 := parseCheckoutPipeline(t, string(yamlOut))
+	if diff := cmp.Diff(p, p2, cmp.Comparer(ordered.EqualSA)); diff != "" {
+		t.Errorf("Pipeline YAML round-trip diff (-orig +new):\n%s\nyaml output:\n%s", diff, yamlOut)
+	}
+
+	// JSON round-trip: marshal, then ingest via ordered.DecodeJSON +
+	// ordered.Unmarshal (the same path the agent uses for JSON pipelines).
+	jsonOut, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("json.Marshal error = %v", err)
+	}
+	src3, err := ordered.DecodeJSON(jsonOut)
+	if err != nil {
+		t.Fatalf("ordered.DecodeJSON error = %v", err)
+	}
+	p3 := new(Pipeline)
+	if err := ordered.Unmarshal(src3, p3); err != nil {
+		t.Fatalf("ordered.Unmarshal JSON error = %v", err)
+	}
+	if diff := cmp.Diff(p, p3, cmp.Comparer(ordered.EqualSA)); diff != "" {
+		t.Errorf("Pipeline JSON round-trip diff (-orig +new):\n%s\njson output:\n%s", diff, jsonOut)
+	}
+
+	// Sanity: skip survives at both levels with their distinct values.
+	if p2.Checkout.Skip == nil || *p2.Checkout.Skip != false {
+		t.Errorf("p2.Checkout.Skip = %v, want ptr(false)", p2.Checkout.Skip)
+	}
+	step := p2.Steps[0].(*CommandStep)
+	if step.Checkout.Skip == nil || *step.Checkout.Skip != true {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(true)", step.Checkout.Skip)
+	}
+}
+
+// TestPipelineCheckoutInterpolationDoesNotMutateSkip exercises the new
+// `if c.Checkout != nil` branches in Pipeline.Interpolate and
+// CommandStep.interpolate. Skip is *bool and never interpolated, but the
+// branches must be reachable without error or surprise.
+func TestPipelineCheckoutInterpolationDoesNotMutateSkip(t *testing.T) {
+	t.Parallel()
+
+	src := `checkout:
+  skip: true
+steps:
+  - command: echo hello
+    checkout:
+      skip: false
+`
+
+	p := parseCheckoutPipeline(t, src)
+
+	runtimeEnv := env.New(env.FromMap(map[string]string{"FOO": "bar"}))
+	if err := p.Interpolate(runtimeEnv, false); err != nil {
+		t.Fatalf("p.Interpolate error = %v", err)
+	}
+
+	if p.Checkout.Skip == nil || *p.Checkout.Skip != true {
+		t.Errorf("p.Checkout.Skip after interpolate = %v, want ptr(true)", p.Checkout.Skip)
+	}
+	step := p.Steps[0].(*CommandStep)
+	if step.Checkout.Skip == nil || *step.Checkout.Skip != false {
+		t.Errorf("step.Checkout.Skip after interpolate = %v, want ptr(false)", step.Checkout.Skip)
+	}
+}
+
+func TestPipelineCheckoutMergeAcrossAllSteps(t *testing.T) {
+	t.Parallel()
+
+	src := `checkout:
+  skip: false
+steps:
+  - command: echo a
+  - command: echo b
+    checkout:
+      skip: true
+  - command: echo c
+`
+
+	p := parseCheckoutPipeline(t, src)
+	if len(p.Steps) != 3 {
+		t.Fatalf("len(p.Steps) = %d, want 3", len(p.Steps))
+	}
+
+	for _, s := range p.Steps {
+		cs, ok := s.(*CommandStep)
+		if !ok {
+			t.Fatalf("step %T is not a *CommandStep", s)
+		}
+		cs.MergeCheckoutFromPipeline(p.Checkout)
+	}
+
+	wantSkip := []*bool{ptr(false), ptr(true), ptr(false)}
+	for i, want := range wantSkip {
+		cs := p.Steps[i].(*CommandStep)
+		if cs.Checkout == nil {
+			t.Errorf("steps[%d].Checkout = nil, want non-nil", i)
+			continue
+		}
+		if cs.Checkout.Skip == nil || *cs.Checkout.Skip != *want {
+			t.Errorf("steps[%d].Checkout.Skip = %v, want %v", i, cs.Checkout.Skip, *want)
+		}
+	}
+}
+
+func TestMergeCheckoutFromPipelineIdempotent(t *testing.T) {
+	t.Parallel()
+
+	pipelineCheckout := &Checkout{Skip: ptr(true)}
+
+	// Single merge.
+	once := &CommandStep{Checkout: &Checkout{Skip: ptr(false)}}
+	once.MergeCheckoutFromPipeline(pipelineCheckout)
+
+	// Double merge from a fresh equivalent step.
+	twice := &CommandStep{Checkout: &Checkout{Skip: ptr(false)}}
+	twice.MergeCheckoutFromPipeline(pipelineCheckout)
+	twice.MergeCheckoutFromPipeline(pipelineCheckout)
+
+	if diff := cmp.Diff(once.Checkout, twice.Checkout, cmp.Comparer(ordered.EqualSA)); diff != "" {
+		t.Errorf("second MergeCheckoutFromPipeline changed result (-once +twice):\n%s", diff)
+	}
+}
+
+func TestMergeCheckoutFromPipelineEmptyParentNoMaterialise(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		parent *Checkout
+	}{
+		{name: "nil parent", parent: nil},
+		{name: "non-nil empty parent", parent: &Checkout{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			step := &CommandStep{}
+			step.MergeCheckoutFromPipeline(tc.parent)
+			if step.Checkout != nil {
+				t.Errorf("step.Checkout = %v, want nil (parent is empty)", step.Checkout)
+			}
+		})
+	}
+}

--- a/step_command_checkout_test.go
+++ b/step_command_checkout_test.go
@@ -194,6 +194,43 @@ func TestMergeCheckoutFromPipelineNilStep(t *testing.T) {
 	}
 }
 
+func TestMergeCheckoutFromPipelineNestedRemainingFieldsAreCopied(t *testing.T) {
+	t.Parallel()
+
+	pipelineCheckout := &Checkout{
+		RemainingFields: map[string]any{
+			"clone_flags": []any{"--depth", "1"},
+			"submodule_paths": map[string]any{
+				"libs": "vendor/libs",
+			},
+		},
+	}
+	step := &CommandStep{}
+	step.MergeCheckoutFromPipeline(pipelineCheckout)
+
+	stepFlags, ok := step.Checkout.RemainingFields["clone_flags"].([]any)
+	if !ok {
+		t.Fatalf("step clone_flags = %T, want []any", step.Checkout.RemainingFields["clone_flags"])
+	}
+	stepFlags[0] = "--no-tags"
+
+	parentFlags, _ := pipelineCheckout.RemainingFields["clone_flags"].([]any)
+	if parentFlags[0] != "--depth" {
+		t.Errorf("mutating step's clone_flags leaked into pipeline; parent[0] = %v", parentFlags[0])
+	}
+
+	stepPaths, ok := step.Checkout.RemainingFields["submodule_paths"].(map[string]any)
+	if !ok {
+		t.Fatalf("step submodule_paths = %T, want map[string]any", step.Checkout.RemainingFields["submodule_paths"])
+	}
+	stepPaths["libs"] = "elsewhere"
+
+	parentPaths, _ := pipelineCheckout.RemainingFields["submodule_paths"].(map[string]any)
+	if parentPaths["libs"] != "vendor/libs" {
+		t.Errorf("mutating step's submodule_paths leaked into pipeline; parent[libs] = %v", parentPaths["libs"])
+	}
+}
+
 func TestPipelineWithCheckoutYAML(t *testing.T) {
 	t.Parallel()
 

--- a/step_command_checkout_test.go
+++ b/step_command_checkout_test.go
@@ -387,10 +387,6 @@ steps:
 	}
 }
 
-// TestPipelineCheckoutInterpolationDoesNotMutateSkip exercises the new
-// `if c.Checkout != nil` branches in Pipeline.Interpolate and
-// CommandStep.interpolate. Skip is *bool and never interpolated, but the
-// branches must be reachable without error or surprise.
 func TestPipelineCheckoutInterpolationDoesNotMutateSkip(t *testing.T) {
 	t.Parallel()
 

--- a/step_command_checkout_test.go
+++ b/step_command_checkout_test.go
@@ -83,31 +83,6 @@ checkout:
 	}
 }
 
-func TestCommandStepCheckoutRejectsBool(t *testing.T) {
-	t.Parallel()
-
-	yamlData := `
-command: echo hello
-checkout: false
-`
-
-	var step CommandStep
-	var node yaml.Node
-	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
-		t.Fatalf("yaml.Unmarshal() error = %v", err)
-	}
-
-	err := ordered.Unmarshal(&node, &step)
-	if err == nil {
-		t.Fatalf("ordered.Unmarshal() error = nil, want error suggesting 'skip: true'")
-	}
-	// 'checkout: false' is the opt-out the user wanted; the suggestion must
-	// be 'skip: true', not 'skip: false'.
-	if !strings.Contains(err.Error(), "skip: true") {
-		t.Errorf("error %q does not suggest 'skip: true'", err.Error())
-	}
-}
-
 func TestPipelineCheckoutRejectsBool(t *testing.T) {
 	t.Parallel()
 

--- a/step_command_checkout_test.go
+++ b/step_command_checkout_test.go
@@ -99,10 +99,12 @@ checkout: false
 
 	err := ordered.Unmarshal(&node, &step)
 	if err == nil {
-		t.Fatalf("ordered.Unmarshal() error = nil, want error mentioning checkout.skip")
+		t.Fatalf("ordered.Unmarshal() error = nil, want error suggesting 'skip: true'")
 	}
-	if !strings.Contains(err.Error(), "checkout.skip") {
-		t.Errorf("error %q does not mention checkout.skip", err.Error())
+	// 'checkout: false' is the opt-out the user wanted; the suggestion must
+	// be 'skip: true', not 'skip: false'.
+	if !strings.Contains(err.Error(), "skip: true") {
+		t.Errorf("error %q does not suggest 'skip: true'", err.Error())
 	}
 }
 
@@ -110,8 +112,9 @@ func TestPipelineCheckoutRejectsBool(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name string
-		in   string
+		name      string
+		in        string
+		wantParts []string
 	}{
 		{
 			name: "false",
@@ -119,6 +122,7 @@ func TestPipelineCheckoutRejectsBool(t *testing.T) {
 steps:
   - command: echo hello
 `,
+			wantParts: []string{"'checkout: false'", "skip: true", "opt out"},
 		},
 		{
 			name: "true",
@@ -126,6 +130,7 @@ steps:
 steps:
   - command: echo hello
 `,
+			wantParts: []string{"'checkout: true'", "skip: false", "omit"},
 		},
 	}
 
@@ -135,10 +140,12 @@ steps:
 
 			_, err := Parse(strings.NewReader(tc.in))
 			if err == nil {
-				t.Fatalf("Parse() error = nil, want error mentioning checkout.skip")
+				t.Fatalf("Parse() error = nil, want error rejecting bool checkout")
 			}
-			if !strings.Contains(err.Error(), "checkout.skip") {
-				t.Errorf("error %q does not mention checkout.skip", err.Error())
+			for _, part := range tc.wantParts {
+				if !strings.Contains(err.Error(), part) {
+					t.Errorf("error %q does not contain %q", err.Error(), part)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Adds a typed `Checkout` model to go-pipeline so consumers can read and round-trip `checkout.skip` without relying on `RemainingFields`.

- `Checkout` struct with `Skip *bool` (tristate: `true` / `false` / absent) and `RemainingFields` for forward-compat. `checkout: false` shorthand is rejected at unmarshal; opt-out is `checkout: { skip: true }`.
- `Checkout` field on `Pipeline` and `CommandStep`, plus `CommandStep.MergeCheckoutFromPipeline` so pipeline-level defaults flow into steps with step-level values winning per leaf.
- Signing: `checkout` is included in `SignedFields`/`ValuesForFields` when non-empty. Existing signatures (no `checkout` set) continue to verify.
- README documents the tristate distinction and pipeline/step precedence.

## Test plan

- [ ] `go test ./...` passes
- [ ] `go vet ./...` clean
- [ ] Round-trip: `checkout: { skip: false }` re-marshals with `skip: false` intact
- [ ] Round-trip: `checkout: {}` re-marshals without a `skip` field