### PR TITLE
Add checkout.depth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,20 @@ The conventional ordering is `Pipeline.Interpolate` first, then merge per step b
 
 Pipelines signed before checkout was a signed field will fail to verify if the step now carries any non-empty Checkout data (for example a step that sets only `submodules`). Re-sign such pipelines when rolling forward to a verifier that includes checkout.
 
+`Checkout.Depth` is a `*int` for the same reason as `Skip`, this is distinguishable from any explicit value, so an inherited pipeline level depth can be cleanly overridden at the step level. The backend validates `depth >= 1`, this library does not.
+
+```yaml
+checkout:
+  depth: 10
+
+steps:
+  - command: echo "Shallow depth defaulting to 10 from build level checkout"
+
+  - command: echo "Deeper shallow at the step level"
+    checkout:
+      depth: 50
+```
+
 ## What's up with the ordered module?
 
 While implementing the pipeline module, we ran into a problem: in some cases, in the buildkite pipeline.yaml, the order of map fields is significant. Because of this, whenever the pipeline gets unmarshaled from YAML or JSON, it needs to be stored in a way that preserves the order of the fields. The `ordered` module is a simple implementation of an ordered map. In most cases, when the pipeline is dealing with user-input maps, it will store them internally as `ordered.Map`s. When the pipeline is marshaled back out to YAML or JSON, the `ordered.Map`s will be marshaled in the correct order.

--- a/checkout.go
+++ b/checkout.go
@@ -30,6 +30,10 @@ type Checkout struct {
 	// the agent default; true/false set the env var explicitly.
 	Submodules *bool `yaml:"submodules,omitempty"`
 
+	// Depth performs a shallow clone of the given depth. nil leaves the agent
+	// default (full clone).
+	Depth *int `yaml:"depth,omitempty"`
+
 	// RemainingFields stores any other top-level mapping items so they
 	// survive an unmarshal-marshal round-trip.
 	RemainingFields map[string]any `yaml:",inline"`
@@ -44,7 +48,7 @@ func (c *Checkout) MarshalJSON() ([]byte, error) {
 // IsEmpty reports whether the checkout is nil or has no fields set.
 // Used by signing to canonicalise empty/nil values.
 func (c *Checkout) IsEmpty() bool {
-	return c == nil || (c.Skip == nil && c.Submodules == nil && len(c.RemainingFields) == 0)
+	return c == nil || (c.Skip == nil && c.Submodules == nil && c.Depth == nil && len(c.RemainingFields) == 0)
 }
 
 // UnmarshalOrdered unmarshals a Checkout from an ordered map. Bool inputs are
@@ -88,6 +92,11 @@ func (c *Checkout) mergeFrom(parent *Checkout) {
 	if c.Submodules == nil && parent.Submodules != nil {
 		v := *parent.Submodules
 		c.Submodules = &v
+	}
+
+	if c.Depth == nil && parent.Depth != nil {
+		v := *parent.Depth
+		c.Depth = &v
 	}
 
 	if len(parent.RemainingFields) == 0 {

--- a/checkout_test.go
+++ b/checkout_test.go
@@ -57,20 +57,30 @@ func TestCheckoutMarshalYAML(t *testing.T) {
 			wantParts: []string{"skip: false", "submodules: true"},
 		},
 		{
+			name: "depth set",
+			c:    Checkout{Depth: ptr(10)},
+			want: "depth: 10\n",
+		},
+		{
+			name:      "skip and depth",
+			c:         Checkout{Skip: ptr(true), Depth: ptr(10)},
+			wantParts: []string{"skip: true", "depth: 10"},
+		},
+		{
 			name: "with remaining fields",
 			c: Checkout{
 				Skip:            ptr(true),
-				RemainingFields: map[string]any{"depth": 1},
+				RemainingFields: map[string]any{"ref": "main"},
 			},
-			wantParts: []string{"skip: true", "depth: 1"},
+			wantParts: []string{"skip: true", "ref: main"},
 		},
 		{
 			name: "remaining fields only",
 			c: Checkout{
-				RemainingFields: map[string]any{"depth": 1},
+				RemainingFields: map[string]any{"ref": "main"},
 			},
-			wantParts: []string{"depth: 1"},
-			notWant:   []string{"skip", "submodules"},
+			wantParts: []string{"ref: main"},
+			notWant:   []string{"skip", "submodules", "depth"},
 		},
 	}
 
@@ -139,12 +149,22 @@ func TestCheckoutMarshalJSON(t *testing.T) {
 			want: `{"skip":false,"submodules":true}`,
 		},
 		{
+			name: "depth set",
+			c:    Checkout{Depth: ptr(10)},
+			want: `{"depth":10}`,
+		},
+		{
+			name: "skip and depth",
+			c:    Checkout{Skip: ptr(true), Depth: ptr(10)},
+			want: `{"depth":10,"skip":true}`,
+		},
+		{
 			name: "with remaining fields",
 			c: Checkout{
 				Skip:            ptr(true),
-				RemainingFields: map[string]any{"depth": 1},
+				RemainingFields: map[string]any{"ref": "main"},
 			},
-			want: `{"depth":1,"skip":true}`,
+			want: `{"ref":"main","skip":true}`,
 		},
 	}
 
@@ -208,20 +228,37 @@ submodules: true`,
 			want: Checkout{Skip: ptr(false), Submodules: ptr(true)},
 		},
 		{
+			name: "depth set",
+			in:   `depth: 10`,
+			want: Checkout{Depth: ptr(10)},
+		},
+		{
+			name: "depth null",
+			in:   `depth: null`,
+			want: Checkout{},
+		},
+		{
+			name: "skip and depth",
+			in: `skip: true
+depth: 10`,
+			want: Checkout{Skip: ptr(true), Depth: ptr(10)},
+		},
+		{
 			name: "with extra fields",
 			in: `skip: true
-depth: 1`,
+ref: main`,
 			want: Checkout{
 				Skip:            ptr(true),
-				RemainingFields: map[string]any{"depth": 1},
+				RemainingFields: map[string]any{"ref": "main"},
 			},
 		},
 		{
-			name: "submodules with unknown sibling fields",
+			name: "submodules and depth with unknown sibling fields",
 			in:   `{submodules: true, depth: 1, gibberish: "x"}`,
 			want: Checkout{
 				Submodules:      ptr(true),
-				RemainingFields: map[string]any{"depth": 1, "gibberish": "x"},
+				Depth:           ptr(1),
+				RemainingFields: map[string]any{"gibberish": "x"},
 			},
 		},
 	}
@@ -260,6 +297,8 @@ func TestCheckoutUnmarshalJSON(t *testing.T) {
 		{name: "submodules null", input: `{"submodules":null}`, want: Checkout{}},
 		{name: "submodules true", input: `{"submodules":true}`, want: Checkout{Submodules: ptr(true)}},
 		{name: "submodules false", input: `{"submodules":false}`, want: Checkout{Submodules: ptr(false)}},
+		{name: "depth null", input: `{"depth":null}`, want: Checkout{}},
+		{name: "depth set", input: `{"depth":10}`, want: Checkout{Depth: ptr(10)}},
 	}
 
 	for _, tc := range cases {
@@ -509,9 +548,17 @@ func TestCheckoutRoundTripYAML(t *testing.T) {
 			in:   "{}\n",
 		},
 		{
+			name: "depth survives",
+			in:   "depth: 10\n",
+		},
+		{
+			name: "skip and depth survive together",
+			in:   "skip: true\ndepth: 10\n",
+		},
+		{
 			name: "unknown fields preserved",
-			in: `depth: 1
-submodules: false
+			in: `submodules: false
+sparse_paths: ["a", "b"]
 `,
 		},
 	}
@@ -562,8 +609,11 @@ func TestCheckoutRoundTripJSON(t *testing.T) {
 		{name: "submodules false", in: `{"submodules":false}`},
 		{name: "submodules true", in: `{"submodules":true}`},
 		{name: "skip and submodules", in: `{"skip":false,"submodules":true}`},
+		{name: "depth", in: `{"depth":10}`},
+		{name: "skip and depth", in: `{"depth":10,"skip":true}`},
+		{name: "submodules and depth", in: `{"depth":10,"submodules":true}`},
 		{name: "empty", in: `{}`},
-		{name: "with remaining", in: `{"depth":1,"skip":true}`},
+		{name: "with remaining", in: `{"ref":"main","skip":true}`},
 	}
 
 	for _, tc := range cases {
@@ -707,27 +757,51 @@ func TestCheckoutMergeFrom(t *testing.T) {
 			want:   &Checkout{Skip: ptr(true), Submodules: ptr(false)},
 		},
 		{
+			name:   "parent only depth",
+			child:  &Checkout{},
+			parent: &Checkout{Depth: ptr(10)},
+			want:   &Checkout{Depth: ptr(10)},
+		},
+		{
+			name:   "child only depth",
+			child:  &Checkout{Depth: ptr(5)},
+			parent: &Checkout{},
+			want:   &Checkout{Depth: ptr(5)},
+		},
+		{
+			name:   "child depth beats parent depth",
+			child:  &Checkout{Depth: ptr(5)},
+			parent: &Checkout{Depth: ptr(10)},
+			want:   &Checkout{Depth: ptr(5)},
+		},
+		{
+			name:   "skip from child, depth from parent",
+			child:  &Checkout{Skip: ptr(false)},
+			parent: &Checkout{Depth: ptr(10)},
+			want:   &Checkout{Skip: ptr(false), Depth: ptr(10)},
+		},
+		{
 			name: "remaining fields disjoint",
 			child: &Checkout{
 				RemainingFields: map[string]any{"submodules_extra": true},
 			},
 			parent: &Checkout{
-				RemainingFields: map[string]any{"depth": 1},
+				RemainingFields: map[string]any{"sparse_paths": []any{"a"}},
 			},
 			want: &Checkout{
-				RemainingFields: map[string]any{"submodules_extra": true, "depth": 1},
+				RemainingFields: map[string]any{"submodules_extra": true, "sparse_paths": []any{"a"}},
 			},
 		},
 		{
 			name: "remaining fields scalar collision child wins",
 			child: &Checkout{
-				RemainingFields: map[string]any{"depth": 5},
+				RemainingFields: map[string]any{"ref": "feature"},
 			},
 			parent: &Checkout{
-				RemainingFields: map[string]any{"depth": 1},
+				RemainingFields: map[string]any{"ref": "main"},
 			},
 			want: &Checkout{
-				RemainingFields: map[string]any{"depth": 5},
+				RemainingFields: map[string]any{"ref": "feature"},
 			},
 		},
 	}
@@ -748,9 +822,9 @@ func TestCheckoutMergeFrom(t *testing.T) {
 // CommandStep.UnmarshalJSON, which decodes through ordered.Unmarshal and
 // honors the inline tag. Direct json.Unmarshal into a Checkout drops the
 // inline extras (Checkout has no custom UnmarshalJSON, matching the
-// Cache/Secret pattern); typed Skip and Submodules still unmarshal in either
-// path. Consumers wanting forward-compat for unknown fields should always go
-// through the parent step's unmarshaler.
+// Cache/Secret pattern); typed Skip, Submodules, and Depth still unmarshal
+// in either path. Consumers wanting forward-compat for unknown fields should
+// always go through the parent step's unmarshaler.
 func TestCommandStepCheckoutJSONUnmarshalExtraFields(t *testing.T) {
 	t.Parallel()
 
@@ -763,7 +837,8 @@ func TestCommandStepCheckoutJSONUnmarshalExtraFields(t *testing.T) {
 
 	want := &Checkout{
 		Submodules:      ptr(true),
-		RemainingFields: map[string]any{"depth": 1, "gibberish": "x"},
+		Depth:           ptr(1),
+		RemainingFields: map[string]any{"gibberish": "x"},
 	}
 	if diff := cmp.Diff(cs.Checkout, want); diff != "" {
 		t.Errorf("CommandStep.Checkout diff (-got +want):\n%s", diff)

--- a/step_command_checkout_test.go
+++ b/step_command_checkout_test.go
@@ -141,9 +141,10 @@ func TestMergeCheckoutFromPipelineNilStep(t *testing.T) {
 	t.Parallel()
 
 	pipelineCheckout := &Checkout{
-		Skip: ptr(true),
+		Skip:  ptr(true),
+		Depth: ptr(10),
 		RemainingFields: map[string]any{
-			"depth": 1,
+			"submodules": true,
 		},
 	}
 	step := &CommandStep{}
@@ -155,6 +156,9 @@ func TestMergeCheckoutFromPipelineNilStep(t *testing.T) {
 	if step.Checkout.Skip == nil || *step.Checkout.Skip != true {
 		t.Errorf("step.Checkout.Skip = %v, want ptr(true)", step.Checkout.Skip)
 	}
+	if step.Checkout.Depth == nil || *step.Checkout.Depth != 10 {
+		t.Errorf("step.Checkout.Depth = %v, want ptr(10)", step.Checkout.Depth)
+	}
 
 	// Verify the copy is independent: mutating the step should not affect
 	// the pipeline.
@@ -163,9 +167,14 @@ func TestMergeCheckoutFromPipelineNilStep(t *testing.T) {
 		t.Errorf("mutating step mutated pipeline; pipelineCheckout.Skip = %v", *pipelineCheckout.Skip)
 	}
 
-	step.Checkout.RemainingFields["depth"] = 99
-	if pipelineCheckout.RemainingFields["depth"] != 1 {
-		t.Errorf("mutating step.RemainingFields mutated pipeline; depth = %v", pipelineCheckout.RemainingFields["depth"])
+	*step.Checkout.Depth = 99
+	if *pipelineCheckout.Depth != 10 {
+		t.Errorf("mutating step mutated pipeline; pipelineCheckout.Depth = %v", *pipelineCheckout.Depth)
+	}
+
+	step.Checkout.RemainingFields["submodules"] = false
+	if pipelineCheckout.RemainingFields["submodules"] != true {
+		t.Errorf("mutating step.RemainingFields mutated pipeline; submodules = %v", pipelineCheckout.RemainingFields["submodules"])
 	}
 }
 
@@ -298,8 +307,8 @@ steps:
 	if p.Checkout.Skip == nil || *p.Checkout.Skip != false {
 		t.Errorf("p.Checkout.Skip = %v, want ptr(false)", p.Checkout.Skip)
 	}
-	if got := p.Checkout.RemainingFields["depth"]; got != 1 {
-		t.Errorf("p.Checkout.RemainingFields[depth] = %v, want 1", got)
+	if p.Checkout.Depth == nil || *p.Checkout.Depth != 1 {
+		t.Errorf("p.Checkout.Depth = %v, want ptr(1)", p.Checkout.Depth)
 	}
 
 	if len(p.Steps) != 2 {
@@ -320,8 +329,8 @@ steps:
 	if step2.Checkout == nil || step2.Checkout.Skip == nil || *step2.Checkout.Skip != false {
 		t.Errorf("step2.Checkout.Skip after merge = %v, want ptr(false)", step2.Checkout)
 	}
-	if got := step2.Checkout.RemainingFields["depth"]; got != 1 {
-		t.Errorf("step2.Checkout.RemainingFields[depth] after merge = %v, want 1", got)
+	if step2.Checkout.Depth == nil || *step2.Checkout.Depth != 1 {
+		t.Errorf("step2.Checkout.Depth after merge = %v, want ptr(1)", step2.Checkout.Depth)
 	}
 }
 


### PR DESCRIPTION
Adds `Depth *int` to the typed `Checkout` model. This is branched off of PR #73, and will be updated from main once this has been merged.

Validation lives on the backend for this, where depth must >= 1.
