### PR TITLE
Db/add lfs to checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,37 @@ would be represented in go as:
 
 This go struct would be marshaled back out to YAML equivalent to the original input.
 
+## Checkout
+
+The `checkout` block configures git checkout behaviour for a pipeline or a command step. The simplest case opts a step out of checkout entirely:
+
+```yaml
+steps:
+  - command: echo "no git checkout for me"
+    checkout:
+      skip: true
+```
+
+`Checkout.Skip` is a `*bool` so the model preserves the difference between `skip: true`, `skip: false`, and an absent `skip`. This matters because `skip: false` at the step level explicitly overrides any pipeline-level or agent-level default that would otherwise skip checkout, while an absent `skip` inherits whatever default applies. Round-trips preserve the distinction; `skip: false` does not collapse to an empty mapping.
+
+A pipeline-level `checkout` is inherited by command steps that do not set their own. The step value wins per leaf when both are set:
+
+```yaml
+checkout:
+  skip: true
+
+steps:
+  - command: echo "inherits skip: true from the pipeline"
+
+  - command: echo "explicit override - checkout runs"
+    checkout:
+      skip: false
+```
+
+After calling `step.MergeCheckoutFromPipeline(pipeline.Checkout)` on the second step, the merged result has `skip: false` (step wins). The first step inherits `skip: true` from the pipeline.
+
+`checkout: false` as a shorthand is rejected at unmarshal time; `checkout` is a multi-field namespace, so opt-out is spelled `checkout: { skip: true }`.
+
 ## What's up with the ordered module?
 
 While implementing the pipeline module, we ran into a problem: in some cases, in the buildkite pipeline.yaml, the order of map fields is significant. Because of this, whenever the pipeline gets unmarshaled from YAML or JSON, it needs to be stored in a way that preserves the order of the fields. The `ordered` module is a simple implementation of an ordered map. In most cases, when the pipeline is dealing with user-input maps, it will store them internally as `ordered.Map`s. When the pipeline is marshaled back out to YAML or JSON, the `ordered.Map`s will be marshaled in the correct order.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ After calling `step.MergeCheckoutFromPipeline(pipeline.Checkout)` on the second 
 
 `checkout: false` as a shorthand is rejected at unmarshal time; `checkout` is a multi-field namespace, so opt-out is spelled `checkout: { skip: true }`.
 
+`Checkout.Depth` is a `*int` for the same reason as `Skip`, this is distinguishable from any explicit value, so an inherited pipeline level depth can be cleanly overridden at the step level. The backend validates `depth >= 1`, this library does not.
+
+```yaml
+checkout:
+  depth: 10
+
+steps:
+  - command: echo "Shallow depth defaulting to 10 from build level checkout"
+
+  - command: echo "Deeper shallow at the step level"
+    checkout:
+      depth: 50
+```
+
 ## What's up with the ordered module?
 
 While implementing the pipeline module, we ran into a problem: in some cases, in the buildkite pipeline.yaml, the order of map fields is significant. Because of this, whenever the pipeline gets unmarshaled from YAML or JSON, it needs to be stored in a way that preserves the order of the fields. The `ordered` module is a simple implementation of an ordered map. In most cases, when the pipeline is dealing with user-input maps, it will store them internally as `ordered.Map`s. When the pipeline is marshaled back out to YAML or JSON, the `ordered.Map`s will be marshaled in the correct order.

--- a/checkout.go
+++ b/checkout.go
@@ -22,6 +22,9 @@ type Checkout struct {
 	// field into the same empty output.
 	Skip *bool `yaml:"skip,omitempty"`
 
+	// Depth as *int to allow integers and not set
+	Depth *int `yaml:"depth,omitempty"`
+
 	// RemainingFields stores any other top-level mapping items so they at least
 	// survive an unmarshal-marshal round-trip.
 	RemainingFields map[string]any `yaml:",inline"`
@@ -33,10 +36,9 @@ func (c *Checkout) MarshalJSON() ([]byte, error) {
 	return inlineFriendlyMarshalJSON(c)
 }
 
-// IsEmpty reports whether the checkout is empty (is nil, or has no Skip and
-// no other data within it). Used by signing to canonicalise empty/nil values.
+// IsEmpty reports whether the checkout is empty, used by signing.
 func (c *Checkout) IsEmpty() bool {
-	return c == nil || (c.Skip == nil && len(c.RemainingFields) == 0)
+	return c == nil || (c.Skip == nil && c.Depth == nil && len(c.RemainingFields) == 0)
 }
 
 // UnmarshalOrdered unmarshals a Checkout from an ordered map. Bool inputs are
@@ -74,6 +76,11 @@ func (c *Checkout) mergeFrom(parent *Checkout) {
 	if c.Skip == nil && parent.Skip != nil {
 		v := *parent.Skip
 		c.Skip = &v
+	}
+
+	if c.Depth == nil && parent.Depth != nil {
+		v := *parent.Depth
+		c.Depth = &v
 	}
 
 	if len(parent.RemainingFields) == 0 {

--- a/checkout.go
+++ b/checkout.go
@@ -25,6 +25,9 @@ type Checkout struct {
 	// Depth as *int to allow integers and not set
 	Depth *int `yaml:"depth,omitempty"`
 
+	// LFS enables Git LFS when true. Defaults to false (zero value).
+	LFS bool `json:"lfs,omitempty" yaml:"lfs,omitempty"`
+
 	// RemainingFields stores any other top-level mapping items so they at least
 	// survive an unmarshal-marshal round-trip.
 	RemainingFields map[string]any `yaml:",inline"`
@@ -38,7 +41,7 @@ func (c *Checkout) MarshalJSON() ([]byte, error) {
 
 // IsEmpty reports whether the checkout is empty, used by signing.
 func (c *Checkout) IsEmpty() bool {
-	return c == nil || (c.Skip == nil && c.Depth == nil && len(c.RemainingFields) == 0)
+	return c == nil || (c.Skip == nil && c.Depth == nil && !c.LFS && len(c.RemainingFields) == 0)
 }
 
 // UnmarshalOrdered unmarshals a Checkout from an ordered map. Bool inputs are
@@ -81,6 +84,10 @@ func (c *Checkout) mergeFrom(parent *Checkout) {
 	if c.Depth == nil && parent.Depth != nil {
 		v := *parent.Depth
 		c.Depth = &v
+	}
+
+	if !c.LFS && parent.LFS {
+		c.LFS = parent.LFS
 	}
 
 	if len(parent.RemainingFields) == 0 {

--- a/checkout.go
+++ b/checkout.go
@@ -1,0 +1,91 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/buildkite/go-pipeline/ordered"
+)
+
+var _ interface {
+	json.Marshaler
+	ordered.Unmarshaler
+	selfInterpolater
+} = (*Checkout)(nil)
+
+var errUnsupportedCheckoutType = fmt.Errorf("unsupported type for checkout")
+
+// Checkout models the checkout configuration for a pipeline or command step.
+type Checkout struct {
+	// Skip is *bool to preserve the tristate distinction (true / false / absent).
+	// `bool` plus `omitempty` would collapse `skip: false` and an absent `skip`
+	// field into the same empty output.
+	Skip *bool `yaml:"skip,omitempty"`
+
+	// RemainingFields stores any other top-level mapping items so they at least
+	// survive an unmarshal-marshal round-trip.
+	RemainingFields map[string]any `yaml:",inline"`
+}
+
+// MarshalJSON marshals the checkout to JSON. Special handling is needed because
+// yaml.v3 has "inline" but encoding/json has no concept of it.
+func (c *Checkout) MarshalJSON() ([]byte, error) {
+	return inlineFriendlyMarshalJSON(c)
+}
+
+// IsEmpty reports whether the checkout is empty (is nil, or has no Skip and
+// no other data within it). Used by signing to canonicalise empty/nil values.
+func (c *Checkout) IsEmpty() bool {
+	return c == nil || (c.Skip == nil && len(c.RemainingFields) == 0)
+}
+
+// UnmarshalOrdered unmarshals a Checkout from an ordered map. Bool inputs are
+// rejected; see the error message for the supported form.
+func (c *Checkout) UnmarshalOrdered(o any) error {
+	switch v := o.(type) {
+	case bool:
+		return fmt.Errorf("unmarshaling checkout: bool is not a valid value; use checkout.skip (e.g. checkout: { skip: %t }) instead", v)
+
+	case *ordered.MapSA:
+		type wrappedCheckout Checkout
+		if err := ordered.Unmarshal(o, (*wrappedCheckout)(c)); err != nil {
+			return fmt.Errorf("unmarshaling checkout: %w", err)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unmarshaling checkout: %w: got %T, want a mapping with checkout.skip and other fields", errUnsupportedCheckoutType, o)
+	}
+}
+
+// interpolate is a no-op today: Skip is *bool, and RemainingFields is not
+// traversed.
+func (c *Checkout) interpolate(stringTransformer) error {
+	return nil
+}
+
+// mergeFrom merges parent values into c. Child wins per top-level key;
+// parent contributes only keys the child does not set.
+func (c *Checkout) mergeFrom(parent *Checkout) {
+	if c == nil || parent == nil {
+		return
+	}
+
+	if c.Skip == nil && parent.Skip != nil {
+		v := *parent.Skip
+		c.Skip = &v
+	}
+
+	if len(parent.RemainingFields) == 0 {
+		return
+	}
+	if c.RemainingFields == nil {
+		c.RemainingFields = make(map[string]any, len(parent.RemainingFields))
+	}
+	for k, pv := range parent.RemainingFields {
+		if _, ok := c.RemainingFields[k]; ok {
+			continue
+		}
+		c.RemainingFields[k] = pv
+	}
+}

--- a/checkout_test.go
+++ b/checkout_test.go
@@ -36,12 +36,22 @@ func TestCheckoutMarshalYAML(t *testing.T) {
 			want: "skip: false\n",
 		},
 		{
+			name: "depth set",
+			c:    Checkout{Depth: ptr(10)},
+			want: "depth: 10\n",
+		},
+		{
+			name: "skip and depth set",
+			c:    Checkout{Skip: ptr(true), Depth: ptr(10)},
+			want: "skip: true\ndepth: 10\n",
+		},
+		{
 			name: "with remaining fields",
 			c: Checkout{
 				Skip:            ptr(true),
-				RemainingFields: map[string]any{"depth": 1},
+				RemainingFields: map[string]any{"submodules": true},
 			},
-			want: "skip: true\ndepth: 1\n",
+			want: "skip: true\nsubmodules: true\n",
 		},
 	}
 
@@ -84,12 +94,22 @@ func TestCheckoutMarshalJSON(t *testing.T) {
 			want: `{"skip":false}`,
 		},
 		{
+			name: "depth set",
+			c:    Checkout{Depth: ptr(10)},
+			want: `{"depth":10}`,
+		},
+		{
+			name: "skip and depth set",
+			c:    Checkout{Skip: ptr(true), Depth: ptr(10)},
+			want: `{"depth":10,"skip":true}`,
+		},
+		{
 			name: "with remaining fields",
 			c: Checkout{
 				Skip:            ptr(true),
-				RemainingFields: map[string]any{"depth": 1},
+				RemainingFields: map[string]any{"submodules": true},
 			},
-			want: `{"depth":1,"skip":true}`,
+			want: `{"skip":true,"submodules":true}`,
 		},
 	}
 
@@ -132,12 +152,23 @@ func TestCheckoutUnmarshalYAML(t *testing.T) {
 			want: Checkout{Skip: ptr(false)},
 		},
 		{
+			name: "depth only",
+			in:   `depth: 10`,
+			want: Checkout{Depth: ptr(10)},
+		},
+		{
+			name: "skip and depth",
+			in: `skip: true
+depth: 10`,
+			want: Checkout{Skip: ptr(true), Depth: ptr(10)},
+		},
+		{
 			name: "with extra fields",
 			in: `skip: true
-depth: 1`,
+submodules: true`,
 			want: Checkout{
 				Skip:            ptr(true),
-				RemainingFields: map[string]any{"depth": 1},
+				RemainingFields: map[string]any{"submodules": true},
 			},
 		},
 	}
@@ -285,9 +316,17 @@ func TestCheckoutRoundTripYAML(t *testing.T) {
 			in:   "{}\n",
 		},
 		{
+			name: "depth survives",
+			in:   "depth: 10\n",
+		},
+		{
+			name: "skip and depth survive together",
+			in:   "skip: true\ndepth: 10\n",
+		},
+		{
 			name: "unknown fields preserved",
-			in: `depth: 1
-submodules: false
+			in: `submodules: false
+sparse_paths: ["a", "b"]
 `,
 		},
 	}
@@ -336,8 +375,10 @@ func TestCheckoutRoundTripJSON(t *testing.T) {
 	}{
 		{name: "skip false", in: `{"skip":false}`},
 		{name: "skip true", in: `{"skip":true}`},
+		{name: "depth", in: `{"depth":10}`},
+		{name: "skip and depth", in: `{"depth":10,"skip":true}`},
 		{name: "empty", in: `{}`},
-		{name: "with remaining", in: `{"depth":1,"skip":true}`},
+		{name: "with remaining", in: `{"skip":true,"submodules":true}`},
 	}
 
 	for _, tc := range cases {
@@ -442,27 +483,51 @@ func TestCheckoutMergeFrom(t *testing.T) {
 			want:   &Checkout{Skip: ptr(false)},
 		},
 		{
+			name:   "parent only depth",
+			child:  &Checkout{},
+			parent: &Checkout{Depth: ptr(10)},
+			want:   &Checkout{Depth: ptr(10)},
+		},
+		{
+			name:   "child only depth",
+			child:  &Checkout{Depth: ptr(5)},
+			parent: &Checkout{},
+			want:   &Checkout{Depth: ptr(5)},
+		},
+		{
+			name:   "child depth beats parent depth",
+			child:  &Checkout{Depth: ptr(5)},
+			parent: &Checkout{Depth: ptr(10)},
+			want:   &Checkout{Depth: ptr(5)},
+		},
+		{
+			name:   "skip from child, depth from parent",
+			child:  &Checkout{Skip: ptr(false)},
+			parent: &Checkout{Depth: ptr(10)},
+			want:   &Checkout{Skip: ptr(false), Depth: ptr(10)},
+		},
+		{
 			name: "remaining fields disjoint",
 			child: &Checkout{
 				RemainingFields: map[string]any{"submodules": true},
 			},
 			parent: &Checkout{
-				RemainingFields: map[string]any{"depth": 1},
+				RemainingFields: map[string]any{"sparse_paths": []any{"a"}},
 			},
 			want: &Checkout{
-				RemainingFields: map[string]any{"submodules": true, "depth": 1},
+				RemainingFields: map[string]any{"submodules": true, "sparse_paths": []any{"a"}},
 			},
 		},
 		{
 			name: "remaining fields scalar collision child wins",
 			child: &Checkout{
-				RemainingFields: map[string]any{"depth": 5},
+				RemainingFields: map[string]any{"submodules": true},
 			},
 			parent: &Checkout{
-				RemainingFields: map[string]any{"depth": 1},
+				RemainingFields: map[string]any{"submodules": false},
 			},
 			want: &Checkout{
-				RemainingFields: map[string]any{"depth": 5},
+				RemainingFields: map[string]any{"submodules": true},
 			},
 		},
 	}

--- a/checkout_test.go
+++ b/checkout_test.go
@@ -1,0 +1,480 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/go-pipeline/ordered"
+	"github.com/buildkite/interpolate"
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCheckoutMarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		c    Checkout
+		want string
+	}{
+		{
+			name: "skip nil",
+			c:    Checkout{},
+			want: "{}\n",
+		},
+		{
+			name: "skip true",
+			c:    Checkout{Skip: ptr(true)},
+			want: "skip: true\n",
+		},
+		{
+			name: "skip false",
+			c:    Checkout{Skip: ptr(false)},
+			want: "skip: false\n",
+		},
+		{
+			name: "with remaining fields",
+			c: Checkout{
+				Skip:            ptr(true),
+				RemainingFields: map[string]any{"depth": 1},
+			},
+			want: "skip: true\ndepth: 1\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := yaml.Marshal(tc.c)
+			if err != nil {
+				t.Fatalf("yaml.Marshal(%#v) error = %v", tc.c, err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("yaml.Marshal(%#v) = %q, want %q", tc.c, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckoutMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		c    Checkout
+		want string
+	}{
+		{
+			name: "skip nil",
+			c:    Checkout{},
+			want: `{}`,
+		},
+		{
+			name: "skip true",
+			c:    Checkout{Skip: ptr(true)},
+			want: `{"skip":true}`,
+		},
+		{
+			name: "skip false",
+			c:    Checkout{Skip: ptr(false)},
+			want: `{"skip":false}`,
+		},
+		{
+			name: "with remaining fields",
+			c: Checkout{
+				Skip:            ptr(true),
+				RemainingFields: map[string]any{"depth": 1},
+			},
+			want: `{"depth":1,"skip":true}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(&tc.c)
+			if err != nil {
+				t.Fatalf("json.Marshal(%#v) error = %v", tc.c, err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("json.Marshal(%#v) = %q, want %q", tc.c, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckoutUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want Checkout
+	}{
+		{
+			name: "empty mapping",
+			in:   `{}`,
+			want: Checkout{},
+		},
+		{
+			name: "skip true",
+			in:   `skip: true`,
+			want: Checkout{Skip: ptr(true)},
+		},
+		{
+			name: "skip false",
+			in:   `skip: false`,
+			want: Checkout{Skip: ptr(false)},
+		},
+		{
+			name: "with extra fields",
+			in: `skip: true
+depth: 1`,
+			want: Checkout{
+				Skip:            ptr(true),
+				RemainingFields: map[string]any{"depth": 1},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c Checkout
+			var node yaml.Node
+			if err := yaml.Unmarshal([]byte(tc.in), &node); err != nil {
+				t.Fatalf("yaml.Unmarshal(%q) error = %v", tc.in, err)
+			}
+			if err := ordered.Unmarshal(&node, &c); err != nil {
+				t.Fatalf("ordered.Unmarshal error = %v", err)
+			}
+			if diff := cmp.Diff(tc.want, c, cmp.Comparer(ordered.EqualSA)); diff != "" {
+				t.Errorf("Checkout diff after unmarshal (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCheckoutUnmarshalRejectsBool(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input any
+	}{
+		{name: "false", input: false},
+		{name: "true", input: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c Checkout
+			err := c.UnmarshalOrdered(tc.input)
+			if err == nil {
+				t.Fatalf("Checkout.UnmarshalOrdered(%v) error = nil, want error", tc.input)
+			}
+			if !strings.Contains(err.Error(), "checkout.skip") {
+				t.Errorf("Checkout.UnmarshalOrdered(%v) error = %q, want it to mention %q", tc.input, err, "checkout.skip")
+			}
+		})
+	}
+}
+
+func TestCheckoutUnmarshalRejectsNonMappings(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input any
+	}{
+		{name: "string", input: "skip"},
+		{name: "int", input: 42},
+		{name: "sequence", input: []any{1, 2, 3}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c Checkout
+			err := c.UnmarshalOrdered(tc.input)
+			if err == nil {
+				t.Fatalf("Checkout.UnmarshalOrdered(%v) error = nil, want error", tc.input)
+			}
+			if !errors.Is(err, errUnsupportedCheckoutType) {
+				t.Errorf("Checkout.UnmarshalOrdered(%v) error = %q, want it to wrap errUnsupportedCheckoutType", tc.input, err)
+			}
+		})
+	}
+}
+
+func TestCheckoutUnmarshalNull(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `checkout:
+steps:
+  - command: echo hello
+`
+
+	p, err := Parse(strings.NewReader(yamlData))
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+	if p.Checkout != nil {
+		t.Errorf("p.Checkout = %v, want nil for explicit YAML null", p.Checkout)
+	}
+}
+
+func TestCheckoutUnmarshalAliases(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `_anchors:
+  base: &base
+    skip: true
+checkout: *base
+steps:
+  - command: echo hello
+    checkout: *base
+`
+
+	p, err := Parse(strings.NewReader(yamlData))
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+	if p.Checkout == nil {
+		t.Fatalf("p.Checkout = nil, want non-nil")
+	}
+	if p.Checkout.Skip == nil || *p.Checkout.Skip != true {
+		t.Errorf("p.Checkout.Skip = %v, want ptr(true)", p.Checkout.Skip)
+	}
+
+	step := p.Steps[0].(*CommandStep)
+	if step.Checkout == nil {
+		t.Fatalf("step.Checkout = nil, want non-nil")
+	}
+	if step.Checkout.Skip == nil || *step.Checkout.Skip != true {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(true)", step.Checkout.Skip)
+	}
+}
+
+func TestCheckoutRoundTripYAML(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{
+			name: "skip false survives",
+			in:   "skip: false\n",
+		},
+		{
+			name: "skip true survives",
+			in:   "skip: true\n",
+		},
+		{
+			name: "empty mapping",
+			in:   "{}\n",
+		},
+		{
+			name: "unknown fields preserved",
+			in: `depth: 1
+submodules: false
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c Checkout
+			var node yaml.Node
+			if err := yaml.Unmarshal([]byte(tc.in), &node); err != nil {
+				t.Fatalf("yaml.Unmarshal(%q) error = %v", tc.in, err)
+			}
+			if err := ordered.Unmarshal(&node, &c); err != nil {
+				t.Fatalf("ordered.Unmarshal error = %v", err)
+			}
+
+			out, err := yaml.Marshal(c)
+			if err != nil {
+				t.Fatalf("yaml.Marshal error = %v", err)
+			}
+
+			// Re-unmarshal to compare structurally.
+			var c2 Checkout
+			var node2 yaml.Node
+			if err := yaml.Unmarshal(out, &node2); err != nil {
+				t.Fatalf("yaml.Unmarshal(%q) error = %v", out, err)
+			}
+			if err := ordered.Unmarshal(&node2, &c2); err != nil {
+				t.Fatalf("ordered.Unmarshal round-trip error = %v", err)
+			}
+
+			if diff := cmp.Diff(c, c2, cmp.Comparer(ordered.EqualSA)); diff != "" {
+				t.Errorf("Checkout round-trip diff (-orig +new):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCheckoutRoundTripJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{name: "skip false", in: `{"skip":false}`},
+		{name: "skip true", in: `{"skip":true}`},
+		{name: "empty", in: `{}`},
+		{name: "with remaining", in: `{"depth":1,"skip":true}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var c Checkout
+			src, err := ordered.DecodeJSON([]byte(tc.in))
+			if err != nil {
+				t.Fatalf("ordered.DecodeJSON(%q) error = %v", tc.in, err)
+			}
+			if err := ordered.Unmarshal(src, &c); err != nil {
+				t.Fatalf("ordered.Unmarshal error = %v", err)
+			}
+
+			out, err := json.Marshal(&c)
+			if err != nil {
+				t.Fatalf("json.Marshal error = %v", err)
+			}
+
+			var c2 Checkout
+			src2, err := ordered.DecodeJSON(out)
+			if err != nil {
+				t.Fatalf("ordered.DecodeJSON round-trip error = %v", err)
+			}
+			if err := ordered.Unmarshal(src2, &c2); err != nil {
+				t.Fatalf("ordered.Unmarshal round-trip error = %v", err)
+			}
+
+			if diff := cmp.Diff(c, c2, cmp.Comparer(ordered.EqualSA)); diff != "" {
+				t.Errorf("Checkout JSON round-trip diff (-orig +new):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCheckoutInterpolationNoOp(t *testing.T) {
+	t.Parallel()
+
+	c := Checkout{Skip: ptr(true)}
+	tf := envInterpolator{
+		env: interpolate.NewMapEnv(map[string]string{"FOO": "bar"}),
+	}
+	if err := c.interpolate(tf); err != nil {
+		t.Fatalf("Checkout.interpolate error = %v", err)
+	}
+	want := Checkout{Skip: ptr(true)}
+	if diff := cmp.Diff(want, c); diff != "" {
+		t.Errorf("Checkout after no-op interpolation (-want +got):\n%s", diff)
+	}
+}
+
+func TestCheckoutMergeFrom(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		child  *Checkout
+		parent *Checkout
+		want   *Checkout
+	}{
+		{
+			name:   "both nil skip",
+			child:  &Checkout{},
+			parent: &Checkout{},
+			want:   &Checkout{},
+		},
+		{
+			name:   "parent only skip",
+			child:  &Checkout{},
+			parent: &Checkout{Skip: ptr(true)},
+			want:   &Checkout{Skip: ptr(true)},
+		},
+		{
+			name:   "child only skip",
+			child:  &Checkout{Skip: ptr(false)},
+			parent: &Checkout{},
+			want:   &Checkout{Skip: ptr(false)},
+		},
+		{
+			name:   "both same",
+			child:  &Checkout{Skip: ptr(true)},
+			parent: &Checkout{Skip: ptr(true)},
+			want:   &Checkout{Skip: ptr(true)},
+		},
+		{
+			name:   "child false beats parent true",
+			child:  &Checkout{Skip: ptr(false)},
+			parent: &Checkout{Skip: ptr(true)},
+			want:   &Checkout{Skip: ptr(false)},
+		},
+		{
+			name:   "child true beats parent false",
+			child:  &Checkout{Skip: ptr(true)},
+			parent: &Checkout{Skip: ptr(false)},
+			want:   &Checkout{Skip: ptr(true)},
+		},
+		{
+			name:   "child inherits parent false",
+			child:  &Checkout{},
+			parent: &Checkout{Skip: ptr(false)},
+			want:   &Checkout{Skip: ptr(false)},
+		},
+		{
+			name: "remaining fields disjoint",
+			child: &Checkout{
+				RemainingFields: map[string]any{"submodules": true},
+			},
+			parent: &Checkout{
+				RemainingFields: map[string]any{"depth": 1},
+			},
+			want: &Checkout{
+				RemainingFields: map[string]any{"submodules": true, "depth": 1},
+			},
+		},
+		{
+			name: "remaining fields scalar collision child wins",
+			child: &Checkout{
+				RemainingFields: map[string]any{"depth": 5},
+			},
+			parent: &Checkout{
+				RemainingFields: map[string]any{"depth": 1},
+			},
+			want: &Checkout{
+				RemainingFields: map[string]any{"depth": 5},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tc.child.mergeFrom(tc.parent)
+			if diff := cmp.Diff(tc.want, tc.child, cmp.Comparer(ordered.EqualSA)); diff != "" {
+				t.Errorf("mergeFrom result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/checkout_test.go
+++ b/checkout_test.go
@@ -46,6 +46,21 @@ func TestCheckoutMarshalYAML(t *testing.T) {
 			want: "skip: true\ndepth: 10\n",
 		},
 		{
+			name: "lfs true",
+			c:    Checkout{LFS: true},
+			want: "lfs: true\n",
+		},
+		{
+			name: "lfs false omitted",
+			c:    Checkout{LFS: false},
+			want: "{}\n",
+		},
+		{
+			name: "lfs true with depth",
+			c:    Checkout{Depth: ptr(10), LFS: true},
+			want: "depth: 10\nlfs: true\n",
+		},
+		{
 			name: "with remaining fields",
 			c: Checkout{
 				Skip:            ptr(true),
@@ -102,6 +117,21 @@ func TestCheckoutMarshalJSON(t *testing.T) {
 			name: "skip and depth set",
 			c:    Checkout{Skip: ptr(true), Depth: ptr(10)},
 			want: `{"depth":10,"skip":true}`,
+		},
+		{
+			name: "lfs true",
+			c:    Checkout{LFS: true},
+			want: `{"lfs":true}`,
+		},
+		{
+			name: "lfs false omitted",
+			c:    Checkout{LFS: false},
+			want: `{}`,
+		},
+		{
+			name: "lfs true with depth",
+			c:    Checkout{Depth: ptr(10), LFS: true},
+			want: `{"depth":10,"lfs":true}`,
 		},
 		{
 			name: "with remaining fields",
@@ -161,6 +191,27 @@ func TestCheckoutUnmarshalYAML(t *testing.T) {
 			in: `skip: true
 depth: 10`,
 			want: Checkout{Skip: ptr(true), Depth: ptr(10)},
+		},
+		{
+			name: "lfs true",
+			in:   `lfs: true`,
+			want: Checkout{LFS: true},
+		},
+		{
+			name: "lfs false",
+			in:   `lfs: false`,
+			want: Checkout{LFS: false},
+		},
+		{
+			name: "lfs omitted defaults to false",
+			in:   `{}`,
+			want: Checkout{},
+		},
+		{
+			name: "lfs with depth",
+			in: `depth: 10
+lfs: true`,
+			want: Checkout{Depth: ptr(10), LFS: true},
 		},
 		{
 			name: "with extra fields",
@@ -324,6 +375,14 @@ func TestCheckoutRoundTripYAML(t *testing.T) {
 			in:   "skip: true\ndepth: 10\n",
 		},
 		{
+			name: "lfs true survives",
+			in:   "lfs: true\n",
+		},
+		{
+			name: "lfs with depth survives",
+			in:   "depth: 10\nlfs: true\n",
+		},
+		{
 			name: "unknown fields preserved",
 			in: `submodules: false
 sparse_paths: ["a", "b"]
@@ -378,6 +437,8 @@ func TestCheckoutRoundTripJSON(t *testing.T) {
 		{name: "depth", in: `{"depth":10}`},
 		{name: "skip and depth", in: `{"depth":10,"skip":true}`},
 		{name: "empty", in: `{}`},
+		{name: "lfs true", in: `{"lfs":true}`},
+		{name: "lfs with depth", in: `{"depth":10,"lfs":true}`},
 		{name: "with remaining", in: `{"skip":true,"submodules":true}`},
 	}
 
@@ -505,6 +566,30 @@ func TestCheckoutMergeFrom(t *testing.T) {
 			child:  &Checkout{Skip: ptr(false)},
 			parent: &Checkout{Depth: ptr(10)},
 			want:   &Checkout{Skip: ptr(false), Depth: ptr(10)},
+		},
+		{
+			name:   "parent only lfs",
+			child:  &Checkout{},
+			parent: &Checkout{LFS: true},
+			want:   &Checkout{LFS: true},
+		},
+		{
+			name:   "child only lfs",
+			child:  &Checkout{LFS: true},
+			parent: &Checkout{},
+			want:   &Checkout{LFS: true},
+		},
+		{
+			name:   "child lfs true beats parent lfs false",
+			child:  &Checkout{LFS: true},
+			parent: &Checkout{LFS: false},
+			want:   &Checkout{LFS: true},
+		},
+		{
+			name:   "lfs from parent, depth from child",
+			child:  &Checkout{Depth: ptr(5)},
+			parent: &Checkout{LFS: true},
+			want:   &Checkout{Depth: ptr(5), LFS: true},
 		},
 		{
 			name: "remaining fields disjoint",

--- a/pipeline.go
+++ b/pipeline.go
@@ -13,9 +13,10 @@ import (
 //
 // Standard caveats apply - see the package comment.
 type Pipeline struct {
-	Steps   Steps          `yaml:"steps"`
-	Env     *ordered.MapSS `yaml:"env,omitempty"`
-	Secrets Secrets        `yaml:"secrets,omitempty"`
+	Steps    Steps          `yaml:"steps"`
+	Env      *ordered.MapSS `yaml:"env,omitempty"`
+	Secrets  Secrets        `yaml:"secrets,omitempty"`
+	Checkout *Checkout      `yaml:"checkout,omitempty"`
 
 	// RemainingFields stores any other top-level mapping items so they at least
 	// survive an unmarshal-marshal round-trip.
@@ -102,6 +103,12 @@ func (p *Pipeline) Interpolate(interpolationEnv InterpolationEnv, preferRuntimeE
 	// variable interpolation on strings. Interpolation is performed in-place.
 	if err := interpolateSlice(tf, p.Steps); err != nil {
 		return err
+	}
+
+	if p.Checkout != nil {
+		if err := p.Checkout.interpolate(tf); err != nil {
+			return err
+		}
 	}
 
 	return interpolateMap(tf, p.RemainingFields)

--- a/signature/pipeline_invariants.go
+++ b/signature/pipeline_invariants.go
@@ -42,6 +42,11 @@ func (c *commandStepWithInvariants) SignedFields() (map[string]any, error) {
 		object["secrets"] = EmptyToNilSlice(c.Secrets)
 	}
 
+	// Only include checkout if non-empty to maintain backward compatibility
+	if !c.Checkout.IsEmpty() {
+		object["checkout"] = c.Checkout
+	}
+
 	// Step env overrides pipeline and build env:
 	// https://buildkite.com/docs/tutorials/pipeline-upgrade#what-is-the-yaml-steps-editor-compatibility-issues
 	// (Beware of inconsistent docs written in the time of legacy steps.)
@@ -74,6 +79,11 @@ func (c *commandStepWithInvariants) ValuesForFields(fields []string) (map[string
 		required["secrets"] = struct{}{}
 	}
 
+	// Only require checkout field if step has checkout
+	if !c.Checkout.IsEmpty() {
+		required["checkout"] = struct{}{}
+	}
+
 	out := make(map[string]any, len(fields))
 	for _, f := range fields {
 		delete(required, f)
@@ -96,6 +106,9 @@ func (c *commandStepWithInvariants) ValuesForFields(fields []string) (map[string
 
 		case "secrets":
 			out["secrets"] = EmptyToNilSlice(c.Secrets)
+
+		case "checkout":
+			out["checkout"] = EmptyToNilPtr(c.Checkout)
 
 		default:
 			if name, has := strings.CutPrefix(f, EnvNamespacePrefix); has {

--- a/signature/pipeline_invariants_test.go
+++ b/signature/pipeline_invariants_test.go
@@ -1,6 +1,7 @@
 package signature
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/buildkite/go-pipeline"
@@ -157,5 +158,115 @@ func TestCommandStepWithInvariants_ValuesForFields_NoSecretsNoSecretsField(t *te
 
 	if diff := cmp.Diff(values, wantValues); diff != "" {
 		t.Errorf("step.ValuesForFields(%v) diff (-got +want):\n%s", fields, diff)
+	}
+}
+
+func ptr[T any](x T) *T { return &x }
+
+func TestCommandStepWithInvariants_SignedFields_WithCheckout(t *testing.T) {
+	t.Parallel()
+
+	checkout := &pipeline.Checkout{Skip: ptr(true)}
+	step := commandStepWithInvariants{
+		CommandStep: pipeline.CommandStep{
+			Command:  "echo hello",
+			Env:      map[string]string{"FOO": "bar"},
+			Plugins:  pipeline.Plugins{},
+			Checkout: checkout,
+		},
+		RepositoryURL: "https://github.com/example/repo",
+	}
+
+	fields, err := step.SignedFields()
+	if err != nil {
+		t.Fatalf("step.SignedFields() error = %v", err)
+	}
+
+	if diff := cmp.Diff(fields["checkout"], checkout); diff != "" {
+		t.Errorf("step.SignedFields()[\"checkout\"] diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestCommandStepWithInvariants_SignedFields_EmptyCheckout(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		checkout *pipeline.Checkout
+	}{
+		{name: "nil", checkout: nil},
+		{name: "zero value", checkout: &pipeline.Checkout{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			step := commandStepWithInvariants{
+				CommandStep: pipeline.CommandStep{
+					Command:  "echo hello",
+					Checkout: tc.checkout,
+				},
+				RepositoryURL: "https://github.com/example/repo",
+			}
+
+			fields, err := step.SignedFields()
+			if err != nil {
+				t.Fatalf("step.SignedFields() error = %v", err)
+			}
+
+			// checkout must be absent when empty, for backward compatibility
+			// with signatures produced before checkout was signed.
+			if _, has := fields["checkout"]; has {
+				t.Errorf("step.SignedFields()[\"checkout\"] = %v, want absent", fields["checkout"])
+			}
+		})
+	}
+}
+
+func TestCommandStepWithInvariants_ValuesForFields_WithCheckout(t *testing.T) {
+	t.Parallel()
+
+	checkout := &pipeline.Checkout{Skip: ptr(true)}
+	step := commandStepWithInvariants{
+		CommandStep: pipeline.CommandStep{
+			Command:  "echo hello",
+			Plugins:  pipeline.Plugins{},
+			Checkout: checkout,
+		},
+		RepositoryURL: "https://github.com/example/repo",
+	}
+
+	fields := []string{"command", "env", "plugins", "matrix", "repository_url", "checkout"}
+	values, err := step.ValuesForFields(fields)
+	if err != nil {
+		t.Fatalf("step.ValuesForFields() error = %v", err)
+	}
+
+	if diff := cmp.Diff(values["checkout"], checkout); diff != "" {
+		t.Errorf("step.ValuesForFields()[\"checkout\"] diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestCommandStepWithInvariants_ValuesForFields_MissingCheckoutField(t *testing.T) {
+	t.Parallel()
+
+	step := commandStepWithInvariants{
+		CommandStep: pipeline.CommandStep{
+			Command:  "echo hello",
+			Plugins:  pipeline.Plugins{},
+			Checkout: &pipeline.Checkout{Skip: ptr(true)},
+		},
+		RepositoryURL: "https://github.com/example/repo",
+	}
+
+	// Step has checkout but verifier didn't ask for it - should fail.
+	fields := []string{"command", "env", "plugins", "matrix", "repository_url"}
+	_, err := step.ValuesForFields(fields)
+	if err == nil {
+		t.Fatalf("step.ValuesForFields(%v) error = nil, want error mentioning checkout", fields)
+	}
+	if !strings.Contains(err.Error(), "checkout") {
+		t.Errorf("error %q does not mention checkout", err.Error())
 	}
 }

--- a/step_command.go
+++ b/step_command.go
@@ -37,6 +37,7 @@ type CommandStep struct {
 	Signature *Signature        `yaml:"signature,omitempty"`
 	Matrix    *Matrix           `yaml:"matrix,omitempty"`
 	Cache     *Cache            `yaml:"cache,omitempty"`
+	Checkout  *Checkout         `yaml:"checkout,omitempty"`
 
 	// RemainingFields stores any other top-level mapping items so they at least
 	// survive an unmarshal-marshal round-trip.
@@ -111,6 +112,11 @@ func (c *CommandStep) interpolate(tf stringTransformer) error {
 	if err := interpolateSlice(tf, c.Secrets); err != nil {
 		return fmt.Errorf("interpolating secrets: %w", err)
 	}
+	if c.Checkout != nil {
+		if err := c.Checkout.interpolate(tf); err != nil {
+			return fmt.Errorf("interpolating checkout: %w", err)
+		}
+	}
 
 	switch tf.(type) {
 	case envInterpolator:
@@ -147,6 +153,20 @@ func (c *CommandStep) interpolate(tf stringTransformer) error {
 // Step-level secrets take precedence over pipeline-level secrets for deduplication.
 func (c *CommandStep) MergeSecretsFromPipeline(pipelineSecrets Secrets) {
 	c.Secrets = pipelineSecrets.MergeWith(c.Secrets)
+}
+
+// MergeCheckoutFromPipeline merges pipeline-level checkout config into this
+// step's checkout. Step-level values take precedence per leaf. An empty parent
+// is treated as no-op so callers don't materialise empty `checkout: {}` on
+// steps that didn't have one.
+func (c *CommandStep) MergeCheckoutFromPipeline(pipelineCheckout *Checkout) {
+	if pipelineCheckout.IsEmpty() {
+		return
+	}
+	if c.Checkout == nil {
+		c.Checkout = &Checkout{}
+	}
+	c.Checkout.mergeFrom(pipelineCheckout)
 }
 
 func (CommandStep) stepTag() {}

--- a/step_command_checkout_test.go
+++ b/step_command_checkout_test.go
@@ -1,0 +1,480 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/go-pipeline/internal/env"
+	"github.com/buildkite/go-pipeline/ordered"
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCommandStepWithCheckoutYAML(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+command: echo "hello"
+checkout:
+  skip: false
+`
+
+	var step CommandStep
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+	if err := ordered.Unmarshal(&node, &step); err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	if step.Checkout == nil {
+		t.Fatalf("step.Checkout = nil, want non-nil")
+	}
+	if step.Checkout.Skip == nil || *step.Checkout.Skip != false {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(false)", step.Checkout.Skip)
+	}
+}
+
+func TestCommandStepWithCheckoutJSON(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"command":"echo hello","checkout":{"skip":true}}`)
+
+	got := new(CommandStep)
+	if err := got.UnmarshalJSON(input); err != nil {
+		t.Fatalf("CommandStep.UnmarshalJSON() = %v", err)
+	}
+
+	if got.Checkout == nil {
+		t.Fatalf("step.Checkout = nil, want non-nil")
+	}
+	if got.Checkout.Skip == nil || *got.Checkout.Skip != true {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(true)", got.Checkout.Skip)
+	}
+}
+
+func TestCommandStepCheckoutFalseSurvivesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+command: echo hello
+checkout:
+  skip: false
+`
+
+	var step CommandStep
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+	if err := ordered.Unmarshal(&node, &step); err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	out, err := yaml.Marshal(step)
+	if err != nil {
+		t.Fatalf("yaml.Marshal error = %v", err)
+	}
+
+	if !strings.Contains(string(out), "skip: false") {
+		t.Errorf("YAML output missing 'skip: false':\n%s", out)
+	}
+}
+
+func TestCommandStepCheckoutRejectsBool(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+command: echo hello
+checkout: false
+`
+
+	var step CommandStep
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+
+	err := ordered.Unmarshal(&node, &step)
+	if err == nil {
+		t.Fatalf("ordered.Unmarshal() error = nil, want error mentioning checkout.skip")
+	}
+	if !strings.Contains(err.Error(), "checkout.skip") {
+		t.Errorf("error %q does not mention checkout.skip", err.Error())
+	}
+}
+
+func TestPipelineCheckoutRejectsBool(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{
+			name: "false",
+			in: `checkout: false
+steps:
+  - command: echo hello
+`,
+		},
+		{
+			name: "true",
+			in: `checkout: true
+steps:
+  - command: echo hello
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Parse(strings.NewReader(tc.in))
+			if err == nil {
+				t.Fatalf("Parse() error = nil, want error mentioning checkout.skip")
+			}
+			if !strings.Contains(err.Error(), "checkout.skip") {
+				t.Errorf("error %q does not mention checkout.skip", err.Error())
+			}
+		})
+	}
+}
+
+func TestMergeCheckoutFromPipelineNilPipeline(t *testing.T) {
+	t.Parallel()
+
+	step := &CommandStep{Checkout: &Checkout{Skip: ptr(true)}}
+	step.MergeCheckoutFromPipeline(nil)
+
+	if step.Checkout == nil || step.Checkout.Skip == nil || *step.Checkout.Skip != true {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(true) preserved", step.Checkout)
+	}
+}
+
+func TestMergeCheckoutFromPipelineNilStep(t *testing.T) {
+	t.Parallel()
+
+	pipelineCheckout := &Checkout{
+		Skip: ptr(true),
+		RemainingFields: map[string]any{
+			"depth": 1,
+		},
+	}
+	step := &CommandStep{}
+	step.MergeCheckoutFromPipeline(pipelineCheckout)
+
+	if step.Checkout == nil {
+		t.Fatalf("step.Checkout = nil, want copy of pipeline checkout")
+	}
+	if step.Checkout.Skip == nil || *step.Checkout.Skip != true {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(true)", step.Checkout.Skip)
+	}
+
+	// Verify the copy is independent: mutating the step should not affect
+	// the pipeline.
+	*step.Checkout.Skip = false
+	if *pipelineCheckout.Skip != true {
+		t.Errorf("mutating step mutated pipeline; pipelineCheckout.Skip = %v", *pipelineCheckout.Skip)
+	}
+
+	step.Checkout.RemainingFields["depth"] = 99
+	if pipelineCheckout.RemainingFields["depth"] != 1 {
+		t.Errorf("mutating step.RemainingFields mutated pipeline; depth = %v", pipelineCheckout.RemainingFields["depth"])
+	}
+}
+
+func TestPipelineWithCheckoutYAML(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+checkout:
+  skip: false
+steps:
+  - command: echo hello
+    checkout:
+      skip: true
+`
+
+	var p Pipeline
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+	if err := ordered.Unmarshal(&node, &p); err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	if p.Checkout == nil {
+		t.Fatalf("p.Checkout = nil, want non-nil")
+	}
+	if p.Checkout.Skip == nil || *p.Checkout.Skip != false {
+		t.Errorf("p.Checkout.Skip = %v, want ptr(false)", p.Checkout.Skip)
+	}
+
+	if len(p.Steps) != 1 {
+		t.Fatalf("len(p.Steps) = %d, want 1", len(p.Steps))
+	}
+	step, ok := p.Steps[0].(*CommandStep)
+	if !ok {
+		t.Fatalf("p.Steps[0] = %T, want *CommandStep", p.Steps[0])
+	}
+	if step.Checkout == nil || step.Checkout.Skip == nil || *step.Checkout.Skip != true {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(true)", step.Checkout)
+	}
+}
+
+func TestPipelineCheckoutSkipFalseRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `checkout:
+    skip: false
+steps:
+    - command: echo hello
+`
+
+	var p Pipeline
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+	if err := ordered.Unmarshal(&node, &p); err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	out, err := yaml.Marshal(&p)
+	if err != nil {
+		t.Fatalf("yaml.Marshal error = %v", err)
+	}
+
+	if !strings.Contains(string(out), "skip: false") {
+		t.Errorf("Pipeline YAML round-trip lost 'skip: false':\n%s", out)
+	}
+}
+
+func TestPipelineCheckoutMergeAtBothLevels(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `checkout:
+  skip: false
+  depth: 1
+steps:
+  - command: echo hello
+    checkout:
+      skip: true
+  - command: echo bye
+`
+
+	p, err := Parse(strings.NewReader(yamlData))
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+
+	if p.Checkout == nil {
+		t.Fatalf("p.Checkout = nil, want non-nil")
+	}
+	if p.Checkout.Skip == nil || *p.Checkout.Skip != false {
+		t.Errorf("p.Checkout.Skip = %v, want ptr(false)", p.Checkout.Skip)
+	}
+	if got := p.Checkout.RemainingFields["depth"]; got != 1 {
+		t.Errorf("p.Checkout.RemainingFields[depth] = %v, want 1", got)
+	}
+
+	if len(p.Steps) != 2 {
+		t.Fatalf("len(p.Steps) = %d, want 2", len(p.Steps))
+	}
+
+	step1 := p.Steps[0].(*CommandStep)
+	if step1.Checkout == nil || step1.Checkout.Skip == nil || *step1.Checkout.Skip != true {
+		t.Errorf("step1.Checkout.Skip = %v, want ptr(true)", step1.Checkout)
+	}
+
+	step2 := p.Steps[1].(*CommandStep)
+	if step2.Checkout != nil {
+		t.Errorf("step2.Checkout = %v, want nil", step2.Checkout)
+	}
+
+	step2.MergeCheckoutFromPipeline(p.Checkout)
+	if step2.Checkout == nil || step2.Checkout.Skip == nil || *step2.Checkout.Skip != false {
+		t.Errorf("step2.Checkout.Skip after merge = %v, want ptr(false)", step2.Checkout)
+	}
+	if got := step2.Checkout.RemainingFields["depth"]; got != 1 {
+		t.Errorf("step2.Checkout.RemainingFields[depth] after merge = %v, want 1", got)
+	}
+}
+
+// parseCheckoutPipeline parses a pipeline at the public API level and asserts
+// the basic structure (one or more *CommandStep) shared by several tests below.
+func parseCheckoutPipeline(t *testing.T, src string) *Pipeline {
+	t.Helper()
+	p, err := Parse(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+	return p
+}
+
+func TestPipelineCheckoutParseAndMarshalRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	src := `checkout:
+  skip: false
+steps:
+  - command: echo hello
+    checkout:
+      skip: true
+`
+
+	p := parseCheckoutPipeline(t, src)
+
+	// YAML round-trip: marshal, re-parse, compare.
+	yamlOut, err := yaml.Marshal(p)
+	if err != nil {
+		t.Fatalf("yaml.Marshal error = %v", err)
+	}
+	p2 := parseCheckoutPipeline(t, string(yamlOut))
+	if diff := cmp.Diff(p, p2, cmp.Comparer(ordered.EqualSA)); diff != "" {
+		t.Errorf("Pipeline YAML round-trip diff (-orig +new):\n%s\nyaml output:\n%s", diff, yamlOut)
+	}
+
+	// JSON round-trip: marshal, then ingest via ordered.DecodeJSON +
+	// ordered.Unmarshal (the same path the agent uses for JSON pipelines).
+	jsonOut, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("json.Marshal error = %v", err)
+	}
+	src3, err := ordered.DecodeJSON(jsonOut)
+	if err != nil {
+		t.Fatalf("ordered.DecodeJSON error = %v", err)
+	}
+	p3 := new(Pipeline)
+	if err := ordered.Unmarshal(src3, p3); err != nil {
+		t.Fatalf("ordered.Unmarshal JSON error = %v", err)
+	}
+	if diff := cmp.Diff(p, p3, cmp.Comparer(ordered.EqualSA)); diff != "" {
+		t.Errorf("Pipeline JSON round-trip diff (-orig +new):\n%s\njson output:\n%s", diff, jsonOut)
+	}
+
+	// Sanity: skip survives at both levels with their distinct values.
+	if p2.Checkout.Skip == nil || *p2.Checkout.Skip != false {
+		t.Errorf("p2.Checkout.Skip = %v, want ptr(false)", p2.Checkout.Skip)
+	}
+	step := p2.Steps[0].(*CommandStep)
+	if step.Checkout.Skip == nil || *step.Checkout.Skip != true {
+		t.Errorf("step.Checkout.Skip = %v, want ptr(true)", step.Checkout.Skip)
+	}
+}
+
+// TestPipelineCheckoutInterpolationDoesNotMutateSkip exercises the new
+// `if c.Checkout != nil` branches in Pipeline.Interpolate and
+// CommandStep.interpolate. Skip is *bool and never interpolated, but the
+// branches must be reachable without error or surprise.
+func TestPipelineCheckoutInterpolationDoesNotMutateSkip(t *testing.T) {
+	t.Parallel()
+
+	src := `checkout:
+  skip: true
+steps:
+  - command: echo hello
+    checkout:
+      skip: false
+`
+
+	p := parseCheckoutPipeline(t, src)
+
+	runtimeEnv := env.New(env.FromMap(map[string]string{"FOO": "bar"}))
+	if err := p.Interpolate(runtimeEnv, false); err != nil {
+		t.Fatalf("p.Interpolate error = %v", err)
+	}
+
+	if p.Checkout.Skip == nil || *p.Checkout.Skip != true {
+		t.Errorf("p.Checkout.Skip after interpolate = %v, want ptr(true)", p.Checkout.Skip)
+	}
+	step := p.Steps[0].(*CommandStep)
+	if step.Checkout.Skip == nil || *step.Checkout.Skip != false {
+		t.Errorf("step.Checkout.Skip after interpolate = %v, want ptr(false)", step.Checkout.Skip)
+	}
+}
+
+func TestPipelineCheckoutMergeAcrossAllSteps(t *testing.T) {
+	t.Parallel()
+
+	src := `checkout:
+  skip: false
+steps:
+  - command: echo a
+  - command: echo b
+    checkout:
+      skip: true
+  - command: echo c
+`
+
+	p := parseCheckoutPipeline(t, src)
+	if len(p.Steps) != 3 {
+		t.Fatalf("len(p.Steps) = %d, want 3", len(p.Steps))
+	}
+
+	for _, s := range p.Steps {
+		cs, ok := s.(*CommandStep)
+		if !ok {
+			t.Fatalf("step %T is not a *CommandStep", s)
+		}
+		cs.MergeCheckoutFromPipeline(p.Checkout)
+	}
+
+	wantSkip := []*bool{ptr(false), ptr(true), ptr(false)}
+	for i, want := range wantSkip {
+		cs := p.Steps[i].(*CommandStep)
+		if cs.Checkout == nil {
+			t.Errorf("steps[%d].Checkout = nil, want non-nil", i)
+			continue
+		}
+		if cs.Checkout.Skip == nil || *cs.Checkout.Skip != *want {
+			t.Errorf("steps[%d].Checkout.Skip = %v, want %v", i, cs.Checkout.Skip, *want)
+		}
+	}
+}
+
+func TestMergeCheckoutFromPipelineIdempotent(t *testing.T) {
+	t.Parallel()
+
+	pipelineCheckout := &Checkout{Skip: ptr(true)}
+
+	// Single merge.
+	once := &CommandStep{Checkout: &Checkout{Skip: ptr(false)}}
+	once.MergeCheckoutFromPipeline(pipelineCheckout)
+
+	// Double merge from a fresh equivalent step.
+	twice := &CommandStep{Checkout: &Checkout{Skip: ptr(false)}}
+	twice.MergeCheckoutFromPipeline(pipelineCheckout)
+	twice.MergeCheckoutFromPipeline(pipelineCheckout)
+
+	if diff := cmp.Diff(once.Checkout, twice.Checkout, cmp.Comparer(ordered.EqualSA)); diff != "" {
+		t.Errorf("second MergeCheckoutFromPipeline changed result (-once +twice):\n%s", diff)
+	}
+}
+
+func TestMergeCheckoutFromPipelineEmptyParentNoMaterialise(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		parent *Checkout
+	}{
+		{name: "nil parent", parent: nil},
+		{name: "non-nil empty parent", parent: &Checkout{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			step := &CommandStep{}
+			step.MergeCheckoutFromPipeline(tc.parent)
+			if step.Checkout != nil {
+				t.Errorf("step.Checkout = %v, want nil (parent is empty)", step.Checkout)
+			}
+		})
+	}
+}

--- a/step_command_checkout_test.go
+++ b/step_command_checkout_test.go
@@ -159,9 +159,10 @@ func TestMergeCheckoutFromPipelineNilStep(t *testing.T) {
 	t.Parallel()
 
 	pipelineCheckout := &Checkout{
-		Skip: ptr(true),
+		Skip:  ptr(true),
+		Depth: ptr(10),
 		RemainingFields: map[string]any{
-			"depth": 1,
+			"submodules": true,
 		},
 	}
 	step := &CommandStep{}
@@ -173,6 +174,9 @@ func TestMergeCheckoutFromPipelineNilStep(t *testing.T) {
 	if step.Checkout.Skip == nil || *step.Checkout.Skip != true {
 		t.Errorf("step.Checkout.Skip = %v, want ptr(true)", step.Checkout.Skip)
 	}
+	if step.Checkout.Depth == nil || *step.Checkout.Depth != 10 {
+		t.Errorf("step.Checkout.Depth = %v, want ptr(10)", step.Checkout.Depth)
+	}
 
 	// Verify the copy is independent: mutating the step should not affect
 	// the pipeline.
@@ -181,9 +185,14 @@ func TestMergeCheckoutFromPipelineNilStep(t *testing.T) {
 		t.Errorf("mutating step mutated pipeline; pipelineCheckout.Skip = %v", *pipelineCheckout.Skip)
 	}
 
-	step.Checkout.RemainingFields["depth"] = 99
-	if pipelineCheckout.RemainingFields["depth"] != 1 {
-		t.Errorf("mutating step.RemainingFields mutated pipeline; depth = %v", pipelineCheckout.RemainingFields["depth"])
+	*step.Checkout.Depth = 99
+	if *pipelineCheckout.Depth != 10 {
+		t.Errorf("mutating step mutated pipeline; pipelineCheckout.Depth = %v", *pipelineCheckout.Depth)
+	}
+
+	step.Checkout.RemainingFields["submodules"] = false
+	if pipelineCheckout.RemainingFields["submodules"] != true {
+		t.Errorf("mutating step.RemainingFields mutated pipeline; submodules = %v", pipelineCheckout.RemainingFields["submodules"])
 	}
 }
 
@@ -279,8 +288,8 @@ steps:
 	if p.Checkout.Skip == nil || *p.Checkout.Skip != false {
 		t.Errorf("p.Checkout.Skip = %v, want ptr(false)", p.Checkout.Skip)
 	}
-	if got := p.Checkout.RemainingFields["depth"]; got != 1 {
-		t.Errorf("p.Checkout.RemainingFields[depth] = %v, want 1", got)
+	if p.Checkout.Depth == nil || *p.Checkout.Depth != 1 {
+		t.Errorf("p.Checkout.Depth = %v, want ptr(1)", p.Checkout.Depth)
 	}
 
 	if len(p.Steps) != 2 {
@@ -301,8 +310,8 @@ steps:
 	if step2.Checkout == nil || step2.Checkout.Skip == nil || *step2.Checkout.Skip != false {
 		t.Errorf("step2.Checkout.Skip after merge = %v, want ptr(false)", step2.Checkout)
 	}
-	if got := step2.Checkout.RemainingFields["depth"]; got != 1 {
-		t.Errorf("step2.Checkout.RemainingFields[depth] after merge = %v, want 1", got)
+	if step2.Checkout.Depth == nil || *step2.Checkout.Depth != 1 {
+		t.Errorf("step2.Checkout.Depth after merge = %v, want ptr(1)", step2.Checkout.Depth)
 	}
 }
 


### PR DESCRIPTION
This PR branches off  #76 and adds `LFS bool` as a  field to the Checkout struct in the go-pipeline library

## Changes

- Adds `LFS bool` field to `Checkout` with `json:"lfs,omitempty" yaml:"lfs,omitempty"` tags
- Updates `IsEmpty()` and `mergeFrom()` to account for the new field
- Adds unit tests for marshal/unmarshal, round-trip, and merge behaviour