### PR TITLE
Add commit verification field to checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ This go struct would be marshaled back out to YAML equivalent to the original in
 
 ## Checkout
 
-The `checkout` block configures git checkout behavior for a pipeline or a command step. It supports `skip`, `submodules`, `depth`, `lfs`, `ssh_secret`, and a nested `flags` mapping. `skip`, `submodules`, and `lfs` are `*bool`, so the model preserves the difference between `true`, `false`, and an absent value; `depth` (`*int`) and `ssh_secret` (`*string`) keep the same distinction between an explicit value and an absent one; `flags` carries per-phase git overrides.
+The `checkout` block configures git checkout behavior for a pipeline or a command step. It supports `skip`, `submodules`, `depth`, `lfs`, `ssh_secret`, `commit_verification`, and a nested `flags` mapping. `skip`, `lfs` and `submodules` are `*bool`, so the model preserves the difference between `true`, `false`, and an absent value; `depth` (`*int`) and `ssh_secret` (`*string`) keep the same distinction between an explicit value and an absent one; `flags` carries per-phase git overrides. `commit_verification` is a `string` and supports `warn` or `strict` values.
 
 The simplest case opts a step out of checkout entirely:
 
@@ -149,6 +149,15 @@ steps:
   - command: make test
     checkout:
       ssh_secret: deploy-key
+```
+
+`commit_verification` enables a verification step which ensures that the specified commit SHA genuinely exists on the specified branch. Allowed values are `warn` or `strict`. `warn` logs a warning but allows the checkout to proceed; `strict` will fail the checkout with an error if it determines that the SHA doesn't exist on the branch.
+
+```yaml
+steps:
+  - command: build.sh
+    checkout:
+      commit_verification: strict
 ```
 
 `flags` carries per-phase git invocation overrides for `clone`, `fetch`, `checkout`, and `clean`:

--- a/signature/pipeline_invariants_test.go
+++ b/signature/pipeline_invariants_test.go
@@ -270,3 +270,32 @@ func TestCommandStepWithInvariants_ValuesForFields_MissingCheckoutField(t *testi
 		t.Errorf("error %q does not mention checkout", err.Error())
 	}
 }
+
+func TestCommandStepWithInvariants_SignedFields_WithCommitVerification(t *testing.T) {
+	t.Parallel()
+
+	checkout := &pipeline.Checkout{CommitVerification: "strict"}
+	step := commandStepWithInvariants{
+		CommandStep: pipeline.CommandStep{
+			Command:  "echo hello",
+			Plugins:  pipeline.Plugins{},
+			Checkout: checkout,
+		},
+		RepositoryURL: "https://github.com/example/repo",
+	}
+
+	fields, err := step.SignedFields()
+	if err != nil {
+		t.Fatalf("step.SignedFields() error = %v", err)
+	}
+
+	// checkout should be present since CommitVerification is non-empty.
+	got, has := fields["checkout"]
+	if !has {
+		t.Fatalf("step.SignedFields()[\"checkout\"] absent, want present")
+	}
+
+	if diff := cmp.Diff(got, checkout); diff != "" {
+		t.Errorf("step.SignedFields()[\"checkout\"] diff (-got +want):\n%s", diff)
+	}
+}

--- a/step_command_checkout.go
+++ b/step_command_checkout.go
@@ -43,6 +43,10 @@ type Checkout struct {
 	// json.Unmarshal would otherwise drop it. Marshal output is unaffected:
 	// inlineFriendlyMarshalJSON derives JSON keys from the yaml tag.
 	SSHSecret *string `json:"ssh_secret,omitempty" yaml:"ssh_secret,omitempty"`
+	// CommitVerification controls whether the agent verifies the commit
+	// exists on the expected branch. "strict" fails on definitive mismatch;
+	// "warn" only logs. Empty disables verification.
+	CommitVerification string `json:"commit_verification,omitempty" yaml:"commit_verification,omitempty"`
 	// Depth performs a shallow clone of the given depth. nil leaves the
 	// agent default (full clone).
 	Depth *int `yaml:"depth,omitempty"`
@@ -80,6 +84,7 @@ func (c *Checkout) IsEmpty() bool {
 		(c.Skip == nil &&
 			c.Submodules == nil &&
 			c.SSHSecret == nil &&
+			c.CommitVerification == "" &&
 			c.Depth == nil &&
 			c.LFS == nil &&
 			c.Sparse == nil &&
@@ -196,6 +201,10 @@ func (c *Checkout) mergeFrom(parent *Checkout) *Checkout {
 	if c.SSHSecret == nil && parent.SSHSecret != nil {
 		v := *parent.SSHSecret
 		c.SSHSecret = &v
+	}
+
+	if c.CommitVerification == "" && parent.CommitVerification != "" {
+		c.CommitVerification = parent.CommitVerification
 	}
 
 	if c.Depth == nil && parent.Depth != nil {

--- a/step_command_checkout_test.go
+++ b/step_command_checkout_test.go
@@ -2198,6 +2198,7 @@ func TestCommandStepMergeCheckoutLFS(t *testing.T) {
 			t.Errorf("mutating step leaked to parent.LFS = %v", *parent.LFS)
 		}
 	})
+}
 
 // --- CommitVerification tests ---
 

--- a/step_command_checkout_test.go
+++ b/step_command_checkout_test.go
@@ -2198,4 +2198,255 @@ func TestCommandStepMergeCheckoutLFS(t *testing.T) {
 			t.Errorf("mutating step leaked to parent.LFS = %v", *parent.LFS)
 		}
 	})
+
+// --- CommitVerification tests ---
+
+func TestCommandStepWithCommitVerificationYAML(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+command: echo "hello"
+checkout:
+  commit_verification: strict
+`
+
+	var step CommandStep
+	var node yaml.Node
+
+	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+	if err := ordered.Unmarshal(&node, &step); err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	if step.Checkout == nil {
+		t.Fatalf("step.Checkout = nil, want non-nil")
+	}
+	if step.Checkout.CommitVerification != "strict" {
+		t.Errorf("step.Checkout.CommitVerification = %q, want %q", step.Checkout.CommitVerification, "strict")
+	}
+}
+
+func TestCommandStepWithCommitVerificationJSON(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"command":"echo hello","checkout":{"commit_verification":"warn"}}`)
+
+	got := new(CommandStep)
+	if err := got.UnmarshalJSON(input); err != nil {
+		t.Fatalf("CommandStep.UnmarshalJSON() = %v", err)
+	}
+
+	if got.Checkout == nil {
+		t.Fatalf("step.Checkout = nil, want non-nil")
+	}
+	if got.Checkout.CommitVerification != "warn" {
+		t.Errorf("step.Checkout.CommitVerification = %q, want %q", got.Checkout.CommitVerification, "warn")
+	}
+}
+
+func TestPipelineCommitVerificationMergeAtBothLevels(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `checkout:
+  commit_verification: strict
+steps:
+  - command: echo hello
+    checkout:
+      commit_verification: warn
+  - command: echo bye
+`
+
+	p, err := Parse(strings.NewReader(yamlData))
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+
+	if p.Checkout == nil {
+		t.Fatalf("p.Checkout = nil, want non-nil")
+	}
+	if p.Checkout.CommitVerification != "strict" {
+		t.Errorf("p.Checkout.CommitVerification = %q, want %q", p.Checkout.CommitVerification, "strict")
+	}
+
+	if len(p.Steps) != 2 {
+		t.Fatalf("len(p.Steps) = %d, want 2", len(p.Steps))
+	}
+
+	// Step 1 has its own commit_verification: warn — should keep it.
+	step1 := p.Steps[0].(*CommandStep)
+	if step1.Checkout == nil {
+		t.Fatalf("step1.Checkout = nil, want non-nil")
+	}
+	if step1.Checkout.CommitVerification != "warn" {
+		t.Errorf("step1.Checkout.CommitVerification = %q, want %q", step1.Checkout.CommitVerification, "warn")
+	}
+
+	// Step 2 has no checkout — should be nil before merge.
+	step2 := p.Steps[1].(*CommandStep)
+	if step2.Checkout != nil {
+		t.Errorf("step2.Checkout = %v, want nil before merge", step2.Checkout)
+	}
+
+	// After merge, step 1 keeps "warn", step 2 inherits "strict".
+	step1.MergeCheckoutFromPipeline(p.Checkout)
+	step2.MergeCheckoutFromPipeline(p.Checkout)
+
+	if step1.Checkout.CommitVerification != "warn" {
+		t.Errorf("step1.Checkout.CommitVerification after merge = %q, want %q", step1.Checkout.CommitVerification, "warn")
+	}
+	if step2.Checkout == nil {
+		t.Fatalf("step2.Checkout = nil after merge, want non-nil")
+	}
+	if step2.Checkout.CommitVerification != "strict" {
+		t.Errorf("step2.Checkout.CommitVerification after merge = %q, want %q", step2.Checkout.CommitVerification, "strict")
+	}
+}
+
+func TestCheckoutIsEmptyWithCommitVerification(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		c    *Checkout
+		want bool
+	}{
+		{
+			name: "only commit verification set",
+			c:    &Checkout{CommitVerification: "strict"},
+			want: false,
+		},
+		{
+			name: "commit verification empty is empty",
+			c:    &Checkout{CommitVerification: ""},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.c.IsEmpty(); got != tc.want {
+				t.Errorf("Checkout.IsEmpty() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckoutMergeCommitVerification(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		child  *Checkout
+		parent *Checkout
+		want   string
+	}{
+		{
+			name:   "parent only",
+			child:  &Checkout{},
+			parent: &Checkout{CommitVerification: "strict"},
+			want:   "strict",
+		},
+		{
+			name:   "child only",
+			child:  &Checkout{CommitVerification: "strict"},
+			parent: &Checkout{},
+			want:   "strict",
+		},
+		{
+			name:   "child beats parent",
+			child:  &Checkout{CommitVerification: "warn"},
+			parent: &Checkout{CommitVerification: "strict"},
+			want:   "warn",
+		},
+		{
+			name:   "child empty inherits parent",
+			child:  &Checkout{CommitVerification: ""},
+			parent: &Checkout{CommitVerification: "strict"},
+			want:   "strict",
+		},
+		{
+			name:   "both empty stays empty",
+			child:  &Checkout{},
+			parent: &Checkout{},
+			want:   "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			step := &CommandStep{Checkout: tc.child}
+			step.MergeCheckoutFromPipeline(tc.parent)
+			if step.Checkout.CommitVerification != tc.want {
+				t.Errorf("CommitVerification after merge = %q, want %q", step.Checkout.CommitVerification, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckoutCommitVerificationYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+command: echo hello
+checkout:
+  commit_verification: strict
+`
+
+	var step CommandStep
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+	if err := ordered.Unmarshal(&node, &step); err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	out, err := yaml.Marshal(step)
+	if err != nil {
+		t.Fatalf("yaml.Marshal error = %v", err)
+	}
+
+	if !strings.Contains(string(out), "commit_verification: strict") {
+		t.Errorf("YAML output missing 'commit_verification: strict':\n%s", out)
+	}
+}
+
+func TestCheckoutCommitVerificationJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"command":"echo hello","checkout":{"commit_verification":"strict"}}`)
+
+	got := new(CommandStep)
+	if err := got.UnmarshalJSON(input); err != nil {
+		t.Fatalf("CommandStep.UnmarshalJSON() = %v", err)
+	}
+
+	out, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal error = %v", err)
+	}
+
+	if !strings.Contains(string(out), `"commit_verification":"strict"`) {
+		t.Errorf("JSON output missing commit_verification:\n%s", out)
+	}
+}
+
+func TestCheckoutCommitVerificationArbitraryValueSurvives(t *testing.T) {
+	t.Parallel()
+
+	// go-pipeline is a data model; validation lives in the schema/backend.
+	input := []byte(`{"command":"echo hello","checkout":{"commit_verification":"bananas"}}`)
+
+	got := new(CommandStep)
+	if err := got.UnmarshalJSON(input); err != nil {
+		t.Fatalf("CommandStep.UnmarshalJSON() = %v", err)
+	}
+
+	if got.Checkout == nil || got.Checkout.CommitVerification != "bananas" {
+		t.Errorf("arbitrary value not preserved: got %q", got.Checkout.CommitVerification)
+	}
 }


### PR DESCRIPTION
Context: SUP-6533

Adds a `CommitVerification string` field to the `Checkout` struct, supporting the `commit_verification` pipeline YAML/JSON key. This pairs with the schema definition in SUP-6534 / https://github.com/buildkite/pipeline-schema/pull/162 and the agent-side implementation in SUP-6535 / https://github.com/buildkite/agent/pull/3905.