### PR TITLE
fix: Interpolate env vars in cache step fields

### DIFF
--- a/step_command.go
+++ b/step_command.go
@@ -111,6 +111,11 @@ func (c *CommandStep) interpolate(tf stringTransformer) error {
 	if err := interpolateSlice(tf, c.Secrets); err != nil {
 		return fmt.Errorf("interpolating secrets: %w", err)
 	}
+	if c.Cache != nil {
+		if _, err := interpolateAny(tf, c.Cache); err != nil {
+			return fmt.Errorf("interpolating cache: %w", err)
+		}
+	}
 
 	switch tf.(type) {
 	case envInterpolator:

--- a/step_command_cache.go
+++ b/step_command_cache.go
@@ -68,3 +68,16 @@ func (c *Cache) UnmarshalOrdered(o any) error {
 
 	return nil
 }
+
+func (c *Cache) interpolate(tf stringTransformer) error {
+	if err := interpolateString(tf, &c.Name); err != nil {
+		return fmt.Errorf("interpolating cache name: %w", err)
+	}
+	if err := interpolateSlice(tf, c.Paths); err != nil {
+		return fmt.Errorf("interpolating cache paths: %w", err)
+	}
+	if err := interpolateString(tf, &c.Size); err != nil {
+		return fmt.Errorf("interpolating cache size: %w", err)
+	}
+	return nil
+}

--- a/step_command_cache_test.go
+++ b/step_command_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/buildkite/go-pipeline/internal/env"
 	"github.com/buildkite/go-pipeline/ordered"
 	"github.com/google/go-cmp/cmp"
 )
@@ -156,6 +157,73 @@ func TestCacheUnmarshalOrdered(t *testing.T) {
 
 			if diff := cmp.Diff(c, tc.want); diff != "" {
 				t.Errorf("Cache diff after UnmarshalOrdered (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCacheInterpolate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		env   map[string]string
+		input Cache
+		want  Cache
+	}{
+		{
+			name: "interpolate cache name",
+			env:  map[string]string{"BUILDKITE_CACHE_NAME": "random-named"},
+			input: Cache{
+				Name:  "${BUILDKITE_CACHE_NAME}-cache",
+				Paths: []string{"path/to/cache"},
+				Size:  "25g",
+			},
+			want: Cache{
+				Name:  "random-named-cache",
+				Paths: []string{"path/to/cache"},
+				Size:  "25g",
+			},
+		},
+		{
+			name: "interpolate cache path",
+			env:  map[string]string{"BUILDKITE_CACHE_PATH": "path/to/cache"},
+			input: Cache{
+				Name:  "name",
+				Paths: []string{"${BUILDKITE_CACHE_PATH}"},
+				Size:  "25g",
+			},
+			want: Cache{
+				Name:  "name",
+				Paths: []string{"path/to/cache"},
+				Size:  "25g",
+			},
+		},
+		{
+			name: "interpolate cache size",
+			env:  map[string]string{"BUILDKITE_CACHE_SIZE": "25g"},
+			input: Cache{
+				Name:  "name",
+				Paths: []string{"path/to/cache"},
+				Size:  "${BUILDKITE_CACHE_SIZE}",
+			},
+			want: Cache{
+				Name:  "name",
+				Paths: []string{"path/to/cache"},
+				Size:  "25g",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tf := envInterpolator{env: env.New(env.FromMap(tc.env))}
+			if err := tc.input.interpolate(tf); err != nil {
+				t.Fatalf("Cache.interpolate() error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.want, tc.input); diff != "" {
+				t.Errorf("Cache.interpolate got and want do not match:\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Cache name, paths, and size now support BUILDKITE_* env var interpolation in pipeline steps. 

ref: https://linear.app/buildkite/issue/A-1183/2-safety-culturesupport-use-of-environment-variables-for-cache-volume

Add tests for Cache.interpolate in `step_command_cache_test.go` verifying that env vars in name, paths, and size are correctly substituted.
