### PR TITLE
SUP-6214: Add SSHSecret Field to Checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ This go struct would be marshaled back out to YAML equivalent to the original in
 
 ## Checkout
 
-The `checkout` block configures git checkout behavior for a pipeline or a command step. Two fields are supported today: `skip` and `submodules`. Both are `*bool` so the model preserves the difference between `true`, `false`, and an absent value.
+The `checkout` block configures git checkout behavior for a pipeline or a command step. Three fields are supported today: `skip`, `submodules`, and `ssh_secret`. `skip` and `submodules` are `*bool` so the model preserves the difference between `true`, `false`, and an absent value. `ssh_secret` is `*string` for the same reason — nil (absent) is distinguishable from an explicit empty string.
 
 The simplest case opts a step out of checkout entirely:
 
@@ -138,7 +138,14 @@ steps:
       skip: true
 ```
 
-`skip: false` at the step level explicitly overrides any pipeline-level or agent-level default that would otherwise skip checkout, while an absent `skip` inherits whatever default applies. Round-trips preserve the distinction; `skip: false` does not collapse to an empty mapping. `skip` maps to `BUILDKITE_SKIP_CHECKOUT` on the agent (`true` skips the checkout phase; absent leaves it to the agent default). `submodules` follows the same tristate pattern and maps to `BUILDKITE_GIT_SUBMODULES` on the agent (`true` and `false` set the env var explicitly; absent leaves it to the agent default).
+`skip: false` at the step level explicitly overrides any pipeline-level or agent-level default that would otherwise skip checkout, while an absent `skip` inherits whatever default applies. Round-trips preserve the distinction; `skip: false` does not collapse to an empty mapping. `skip` maps to `BUILDKITE_SKIP_CHECKOUT` on the agent (`true` skips the checkout phase; absent leaves it to the agent default). `submodules` follows the same tristate pattern and maps to `BUILDKITE_GIT_SUBMODULES` on the agent (`true` and `false` set the env var explicitly; absent leaves it to the agent default). `ssh_secret` holds the name or ID of a Buildkite Secret containing an SSH private key the agent uses for git checkout — the agent owns retrieval and validation; go-pipeline only parses and round-trips the value.
+
+```yaml
+steps:
+  - command: make test
+    checkout:
+      ssh_secret: deploy-key
+```
 
 A pipeline-level `checkout` provides defaults for command steps. Inheritance is opt-in: the consumer merges pipeline values into each step. After merging the step value wins per leaf, with anything the step didn't set inherited from the pipeline:
 

--- a/checkout.go
+++ b/checkout.go
@@ -42,7 +42,7 @@ type Checkout struct {
 	// field. Marshal output is unaffected — inlineFriendlyMarshalJSON
 	// derives JSON keys from the yaml tag.
 	SSHSecret *string `json:"ssh_secret,omitempty" yaml:"ssh_secret,omitempty"`
-  
+
 	// Depth performs a shallow clone of the given depth. nil leaves the agent
 	// default (full clone).
 	Depth *int `yaml:"depth,omitempty"`
@@ -110,8 +110,8 @@ func (c *Checkout) mergeFrom(parent *Checkout) {
 	if c.SSHSecret == nil && parent.SSHSecret != nil {
 		v := *parent.SSHSecret
 		c.SSHSecret = &v
-  }
-  
+	}
+
 	if c.Depth == nil && parent.Depth != nil {
 		v := *parent.Depth
 		c.Depth = &v

--- a/checkout.go
+++ b/checkout.go
@@ -30,6 +30,19 @@ type Checkout struct {
 	// the agent default; true/false set the env var explicitly.
 	Submodules *bool `yaml:"submodules,omitempty"`
 
+	// SSHSecret is the name or ID of a Buildkite Secret holding an SSH
+	// private key the agent uses for git checkout. *string preserves the
+	// tristate (set / explicit empty string / absent) for the same reasons
+	// Skip and Submodules are *bool. The agent owns secret name validation
+	// and retrieval; go-pipeline only parses and round-trips the value.
+	//
+	// An explicit json tag is needed because the snake_case JSON key does
+	// not case-insensitively match the Go field name (unlike `skip` and
+	// `submodules`), so direct json.Unmarshal would otherwise skip the
+	// field. Marshal output is unaffected — inlineFriendlyMarshalJSON
+	// derives JSON keys from the yaml tag.
+	SSHSecret *string `json:"ssh_secret,omitempty" yaml:"ssh_secret,omitempty"`
+
 	// RemainingFields stores any other top-level mapping items so they
 	// survive an unmarshal-marshal round-trip.
 	RemainingFields map[string]any `yaml:",inline"`
@@ -44,7 +57,7 @@ func (c *Checkout) MarshalJSON() ([]byte, error) {
 // IsEmpty reports whether the checkout is nil or has no fields set.
 // Used by signing to canonicalise empty/nil values.
 func (c *Checkout) IsEmpty() bool {
-	return c == nil || (c.Skip == nil && c.Submodules == nil && len(c.RemainingFields) == 0)
+	return c == nil || (c.Skip == nil && c.Submodules == nil && c.SSHSecret == nil && len(c.RemainingFields) == 0)
 }
 
 // UnmarshalOrdered unmarshals a Checkout from an ordered map. Bool inputs are
@@ -88,6 +101,11 @@ func (c *Checkout) mergeFrom(parent *Checkout) {
 	if c.Submodules == nil && parent.Submodules != nil {
 		v := *parent.Submodules
 		c.Submodules = &v
+	}
+
+	if c.SSHSecret == nil && parent.SSHSecret != nil {
+		v := *parent.SSHSecret
+		c.SSHSecret = &v
 	}
 
 	if len(parent.RemainingFields) == 0 {

--- a/checkout_test.go
+++ b/checkout_test.go
@@ -70,7 +70,20 @@ func TestCheckoutMarshalYAML(t *testing.T) {
 				RemainingFields: map[string]any{"depth": 1},
 			},
 			wantParts: []string{"depth: 1"},
-			notWant:   []string{"skip", "submodules"},
+			notWant:   []string{"skip", "submodules", "ssh_secret"},
+		},
+		{
+			name: "ssh_secret set",
+			c:    Checkout{SSHSecret: ptr("deploy-key")},
+			want: "ssh_secret: deploy-key\n",
+		},
+		{
+			// *string + omitempty must NOT collapse an explicit empty
+			// string into an omitted field; the ticket calls this out
+			// alongside the nil-vs-empty distinction.
+			name:      "ssh_secret empty string preserved",
+			c:         Checkout{SSHSecret: ptr("")},
+			wantParts: []string{"ssh_secret:"},
 		},
 	}
 
@@ -145,6 +158,16 @@ func TestCheckoutMarshalJSON(t *testing.T) {
 				RemainingFields: map[string]any{"depth": 1},
 			},
 			want: `{"depth":1,"skip":true}`,
+		},
+		{
+			name: "ssh_secret set",
+			c:    Checkout{SSHSecret: ptr("deploy-key")},
+			want: `{"ssh_secret":"deploy-key"}`,
+		},
+		{
+			name: "ssh_secret empty string preserved",
+			c:    Checkout{SSHSecret: ptr("")},
+			want: `{"ssh_secret":""}`,
 		},
 	}
 
@@ -224,6 +247,21 @@ depth: 1`,
 				RemainingFields: map[string]any{"depth": 1, "gibberish": "x"},
 			},
 		},
+		{
+			name: "ssh_secret string",
+			in:   `ssh_secret: deploy-key`,
+			want: Checkout{SSHSecret: ptr("deploy-key")},
+		},
+		{
+			name: "ssh_secret quoted empty string",
+			in:   `ssh_secret: ""`,
+			want: Checkout{SSHSecret: ptr("")},
+		},
+		{
+			name: "ssh_secret null",
+			in:   `ssh_secret: null`,
+			want: Checkout{},
+		},
 	}
 
 	for _, tc := range cases {
@@ -260,6 +298,9 @@ func TestCheckoutUnmarshalJSON(t *testing.T) {
 		{name: "submodules null", input: `{"submodules":null}`, want: Checkout{}},
 		{name: "submodules true", input: `{"submodules":true}`, want: Checkout{Submodules: ptr(true)}},
 		{name: "submodules false", input: `{"submodules":false}`, want: Checkout{Submodules: ptr(false)}},
+		{name: "ssh_secret null", input: `{"ssh_secret":null}`, want: Checkout{}},
+		{name: "ssh_secret set", input: `{"ssh_secret":"deploy-key"}`, want: Checkout{SSHSecret: ptr("deploy-key")}},
+		{name: "ssh_secret empty string", input: `{"ssh_secret":""}`, want: Checkout{SSHSecret: ptr("")}},
 	}
 
 	for _, tc := range cases {
@@ -514,6 +555,14 @@ func TestCheckoutRoundTripYAML(t *testing.T) {
 submodules: false
 `,
 		},
+		{
+			name: "ssh_secret set survives",
+			in:   "ssh_secret: deploy-key\n",
+		},
+		{
+			name: "ssh_secret empty string survives",
+			in:   "ssh_secret: \"\"\n",
+		},
 	}
 
 	for _, tc := range cases {
@@ -564,6 +613,8 @@ func TestCheckoutRoundTripJSON(t *testing.T) {
 		{name: "skip and submodules", in: `{"skip":false,"submodules":true}`},
 		{name: "empty", in: `{}`},
 		{name: "with remaining", in: `{"depth":1,"skip":true}`},
+		{name: "ssh_secret set", in: `{"ssh_secret":"deploy-key"}`},
+		{name: "ssh_secret empty string", in: `{"ssh_secret":""}`},
 	}
 
 	for _, tc := range cases {
@@ -637,6 +688,36 @@ func TestCheckoutInterpolationOfRemainingFields(t *testing.T) {
 	}
 }
 
+// IsEmpty gates checkout inclusion in signing (signature/pipeline_invariants.go)
+// and in step materialisation during MergeCheckoutFromPipeline. If SSHSecret
+// did not participate, a Checkout carrying only an ssh_secret could be
+// stripped from a signed payload without detection. The nil/zero baselines
+// anchor the assertion that the new field doesn't inadvertently change
+// "empty" semantics for callers.
+func TestCheckoutIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		c    *Checkout
+		want bool
+	}{
+		{name: "nil receiver", c: nil, want: true},
+		{name: "zero value", c: &Checkout{}, want: true},
+		{name: "ssh_secret set", c: &Checkout{SSHSecret: ptr("deploy-key")}, want: false},
+		{name: "ssh_secret explicit empty string", c: &Checkout{SSHSecret: ptr("")}, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.c.IsEmpty(); got != tc.want {
+				t.Errorf("Checkout.IsEmpty() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCheckoutMergeFrom(t *testing.T) {
 	t.Parallel()
 
@@ -705,6 +786,34 @@ func TestCheckoutMergeFrom(t *testing.T) {
 			child:  &Checkout{Skip: ptr(true)},
 			parent: &Checkout{Submodules: ptr(false)},
 			want:   &Checkout{Skip: ptr(true), Submodules: ptr(false)},
+		},
+		{
+			name:   "parent only ssh_secret",
+			child:  &Checkout{},
+			parent: &Checkout{SSHSecret: ptr("pipeline-key")},
+			want:   &Checkout{SSHSecret: ptr("pipeline-key")},
+		},
+		{
+			name:   "child ssh_secret beats parent",
+			child:  &Checkout{SSHSecret: ptr("step-key")},
+			parent: &Checkout{SSHSecret: ptr("pipeline-key")},
+			want:   &Checkout{SSHSecret: ptr("step-key")},
+		},
+		{
+			// Explicit empty string at the child level must override the
+			// parent: that's the whole reason SSHSecret is *string rather
+			// than string. If the child wanted to inherit the parent value
+			// it would leave the field unset.
+			name:   "child empty ssh_secret beats parent set",
+			child:  &Checkout{SSHSecret: ptr("")},
+			parent: &Checkout{SSHSecret: ptr("pipeline-key")},
+			want:   &Checkout{SSHSecret: ptr("")},
+		},
+		{
+			name:   "child inherits parent empty ssh_secret",
+			child:  &Checkout{},
+			parent: &Checkout{SSHSecret: ptr("")},
+			want:   &Checkout{SSHSecret: ptr("")},
 		},
 		{
 			name: "remaining fields disjoint",

--- a/checkout_test.go
+++ b/checkout_test.go
@@ -79,8 +79,8 @@ func TestCheckoutMarshalYAML(t *testing.T) {
 			c: Checkout{
 				RemainingFields: map[string]any{"ref": "main"},
 			},
-			wantParts: []string{"depth: 1"},
-			notWant:   []string{"skip", "submodules", "ssh_secret"},
+			wantParts: []string{"ref: main"},
+			notWant:   []string{"skip", "submodules", "ssh_secret", "depth"},
 		},
 		{
 			name: "ssh_secret set",
@@ -94,11 +94,10 @@ func TestCheckoutMarshalYAML(t *testing.T) {
 			// exact emitted form (quoted empty scalar) so a future
 			// change to yaml.v3's empty-scalar rendering surfaces here
 			// rather than being silently absorbed by a substring match.
-			name: "ssh_secret empty string preserved",
-			c:    Checkout{SSHSecret: ptr("")},
-			want: "ssh_secret: \"\"\n",
-			wantParts: []string{"ref: main"},
-			notWant:   []string{"skip", "submodules", "depth"},
+			name:    "ssh_secret empty string preserved",
+			c:       Checkout{SSHSecret: ptr("")},
+			want:    "ssh_secret: \"\"\n",
+			notWant: []string{"skip", "submodules", "depth"},
 		},
 	}
 
@@ -869,8 +868,8 @@ func TestCheckoutMergeFrom(t *testing.T) {
 			child:  &Checkout{},
 			parent: &Checkout{SSHSecret: ptr("")},
 			want:   &Checkout{SSHSecret: ptr("")},
-    },
-    {
+		},
+		{
 			name:   "parent only depth",
 			child:  &Checkout{},
 			parent: &Checkout{Depth: ptr(10)},

--- a/checkout_test.go
+++ b/checkout_test.go
@@ -80,10 +80,13 @@ func TestCheckoutMarshalYAML(t *testing.T) {
 		{
 			// *string + omitempty must NOT collapse an explicit empty
 			// string into an omitted field; the ticket calls this out
-			// alongside the nil-vs-empty distinction.
-			name:      "ssh_secret empty string preserved",
-			c:         Checkout{SSHSecret: ptr("")},
-			wantParts: []string{"ssh_secret:"},
+			// alongside the nil-vs-empty distinction. Pinned to the
+			// exact emitted form (quoted empty scalar) so a future
+			// change to yaml.v3's empty-scalar rendering surfaces here
+			// rather than being silently absorbed by a substring match.
+			name: "ssh_secret empty string preserved",
+			c:    Checkout{SSHSecret: ptr("")},
+			want: "ssh_secret: \"\"\n",
 		},
 	}
 

--- a/step_command_checkout_test.go
+++ b/step_command_checkout_test.go
@@ -55,6 +55,52 @@ func TestCommandStepWithCheckoutJSON(t *testing.T) {
 	}
 }
 
+// Matches the example YAML from SUP-6214 verbatim so the diff is easy to
+// trace back to the ticket.
+func TestCommandStepWithCheckoutSSHSecretYAML(t *testing.T) {
+	t.Parallel()
+
+	yamlData := `
+command: "make test"
+checkout:
+  ssh_secret: "deploy-key"
+`
+
+	var step CommandStep
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlData), &node); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+	if err := ordered.Unmarshal(&node, &step); err != nil {
+		t.Fatalf("ordered.Unmarshal() error = %v", err)
+	}
+
+	if step.Checkout == nil {
+		t.Fatalf("step.Checkout = nil, want non-nil")
+	}
+	if step.Checkout.SSHSecret == nil || *step.Checkout.SSHSecret != "deploy-key" {
+		t.Errorf("step.Checkout.SSHSecret = %v, want ptr(%q)", step.Checkout.SSHSecret, "deploy-key")
+	}
+}
+
+func TestCommandStepWithCheckoutSSHSecretJSON(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"command":"make test","checkout":{"ssh_secret":"deploy-key"}}`)
+
+	got := new(CommandStep)
+	if err := got.UnmarshalJSON(input); err != nil {
+		t.Fatalf("CommandStep.UnmarshalJSON() = %v", err)
+	}
+
+	if got.Checkout == nil {
+		t.Fatalf("step.Checkout = nil, want non-nil")
+	}
+	if got.Checkout.SSHSecret == nil || *got.Checkout.SSHSecret != "deploy-key" {
+		t.Errorf("step.Checkout.SSHSecret = %v, want ptr(%q)", got.Checkout.SSHSecret, "deploy-key")
+	}
+}
+
 func TestCommandStepCheckoutFalseSurvivesRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -481,6 +527,78 @@ func TestMergeCheckoutFromPipelineIdempotent(t *testing.T) {
 
 	if diff := cmp.Diff(once.Checkout, twice.Checkout, cmp.Comparer(ordered.EqualSA)); diff != "" {
 		t.Errorf("second MergeCheckoutFromPipeline changed result (-once +twice):\n%s", diff)
+	}
+}
+
+// Exercises the deep-merge story from SUP-6214: a pipeline-level
+// `ssh_secret` propagates to steps that omit it, loses to steps that set
+// their own, and merges per-leaf alongside step-only fields like skip.
+func TestPipelineCheckoutSSHSecretMerge(t *testing.T) {
+	t.Parallel()
+
+	src := `checkout:
+  ssh_secret: "pipeline-key"
+steps:
+  - command: echo "inherits ssh_secret from pipeline"
+  - command: echo "explicit override"
+    checkout:
+      ssh_secret: "step-key"
+  - command: echo "inherits ssh_secret but keeps own skip"
+    checkout:
+      skip: true
+`
+
+	p := parseCheckoutPipeline(t, src)
+	if len(p.Steps) != 3 {
+		t.Fatalf("len(p.Steps) = %d, want 3", len(p.Steps))
+	}
+	for _, s := range p.Steps {
+		s.(*CommandStep).MergeCheckoutFromPipeline(p.Checkout)
+	}
+
+	wants := []struct {
+		skip      *bool
+		sshSecret string
+	}{
+		{sshSecret: "pipeline-key"},
+		{sshSecret: "step-key"},
+		{skip: ptr(true), sshSecret: "pipeline-key"},
+	}
+
+	for i, w := range wants {
+		cs := p.Steps[i].(*CommandStep)
+		if cs.Checkout == nil {
+			t.Errorf("steps[%d].Checkout = nil", i)
+			continue
+		}
+		if cs.Checkout.SSHSecret == nil || *cs.Checkout.SSHSecret != w.sshSecret {
+			t.Errorf("steps[%d].Checkout.SSHSecret = %v, want ptr(%q)", i, cs.Checkout.SSHSecret, w.sshSecret)
+		}
+		switch {
+		case w.skip == nil && cs.Checkout.Skip != nil:
+			t.Errorf("steps[%d].Checkout.Skip = %v, want nil", i, cs.Checkout.Skip)
+		case w.skip != nil && (cs.Checkout.Skip == nil || *cs.Checkout.Skip != *w.skip):
+			t.Errorf("steps[%d].Checkout.Skip = %v, want ptr(%v)", i, cs.Checkout.Skip, *w.skip)
+		}
+	}
+}
+
+// Mirrors TestMergeCheckoutFromPipelineNilStep but for SSHSecret: mutating
+// the step after merging must not leak into the parent pipeline's checkout.
+func TestMergeCheckoutFromPipelineSSHSecretIndependent(t *testing.T) {
+	t.Parallel()
+
+	pipelineCheckout := &Checkout{SSHSecret: ptr("pipeline-key")}
+	step := &CommandStep{}
+	step.MergeCheckoutFromPipeline(pipelineCheckout)
+
+	if step.Checkout == nil || step.Checkout.SSHSecret == nil || *step.Checkout.SSHSecret != "pipeline-key" {
+		t.Fatalf("step.Checkout.SSHSecret = %v, want ptr(%q)", step.Checkout, "pipeline-key")
+	}
+
+	*step.Checkout.SSHSecret = "step-key"
+	if *pipelineCheckout.SSHSecret != "pipeline-key" {
+		t.Errorf("mutating step.Checkout.SSHSecret leaked into pipeline; pipelineCheckout.SSHSecret = %q", *pipelineCheckout.SSHSecret)
 	}
 }
 


### PR DESCRIPTION
This PR is related to https://linear.app/buildkite/issue/SUP-6214/go-pipeline-add-sshsecret-field-to-checkout

It adds a new SSHSecret field to the Checkout model and includes the necessary tests to handle scenarios like when ssh_secret is empty string or null, etc. Also updates `IsEmpty` so signing/verification include ssh_secret.