### PR TITLE
Add iterator methods to ordered.Map, deprecate Range

### DIFF
--- a/interpolate.go
+++ b/interpolate.go
@@ -151,7 +151,7 @@ func interpolateMap[K comparable, V any, M ~map[K]V](tf stringTransformer, m M) 
 // interpolateOrderedMap applies interpolateAny over any type of ordered.Map.
 // The map is altered in-place.
 func interpolateOrderedMap[K comparable, V any](tf stringTransformer, m *ordered.Map[K, V]) error {
-	return m.Range(func(k K, v V) error {
+	for k, v := range m.All {
 		// We interpolate both keys and values.
 		intk, err := interpolateAny(tf, k)
 		if err != nil {
@@ -163,6 +163,6 @@ func interpolateOrderedMap[K comparable, V any](tf stringTransformer, m *ordered
 		}
 
 		m.Replace(k, intk, intv)
-		return nil
-	})
+	}
+	return nil
 }

--- a/ordered/map.go
+++ b/ordered/map.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	"github.com/google/go-cmp/cmp"
 	"gopkg.in/yaml.v3"
@@ -176,12 +177,7 @@ func (m *Map[K, V]) ToMap() map[K]V {
 	if m == nil {
 		return nil
 	}
-	um := make(map[K]V, len(m.index))
-	m.Range(func(k K, v V) error {
-		um[k] = v
-		return nil
-	})
-	return um
+	return maps.Collect(m.All)
 }
 
 // ToMapRecursive converts a weakly typed nested structure consisting of
@@ -192,10 +188,9 @@ func ToMapRecursive(src any) any {
 	switch tsrc := src.(type) {
 	case *Map[string, any]:
 		um := make(map[string]any, len(tsrc.index))
-		tsrc.Range(func(k string, v any) error {
+		for k, v := range tsrc.All {
 			um[k] = ToMapRecursive(v)
-			return nil
-		})
+		}
 		return um
 
 	case []any:
@@ -264,6 +259,7 @@ func (m *Map[K, V]) compact() {
 
 // Range ranges over the map (in order). If f returns an error, it stops ranging
 // and returns that error.
+// Deprecated: Use a for loop ranging over m.All instead.
 func (m *Map[K, V]) Range(f func(k K, v V) error) error {
 	if m.IsZero() {
 		return nil
@@ -279,6 +275,45 @@ func (m *Map[K, V]) Range(f func(k K, v V) error) error {
 	return nil
 }
 
+// All is an iterator over all key-value pairs in the map.
+//
+// Example:
+//
+//	for k, v := range m.All {
+//	    fmt.Printf("Got %v => %v\n", k, v)
+//	}
+func (m *Map[K, V]) All(yield func(K, V) bool) {
+	if m.IsZero() {
+		return
+	}
+	for _, p := range m.items {
+		if p.deleted {
+			continue
+		}
+		if !yield(p.Key, p.Value) {
+			return
+		}
+	}
+}
+
+// Keys is an iterator over all keys in the map.
+//
+// Example:
+//
+//	keys := slices.Collect(m.Keys)
+func (m *Map[K, V]) Keys(yield func(K) bool) {
+	m.All(func(k K, _ V) bool { return yield(k) })
+}
+
+// Values is an iterator over all values in the map.
+//
+// Example:
+//
+//	values := slices.Collect(m.Values)
+func (m *Map[K, V]) Values(yield func(V) bool) {
+	m.All(func(_ K, v V) bool { return yield(v) })
+}
+
 // MarshalJSON marshals the ordered map to JSON. It preserves the map order in
 // the output.
 func (m *Map[K, V]) MarshalJSON() ([]byte, error) {
@@ -286,7 +321,7 @@ func (m *Map[K, V]) MarshalJSON() ([]byte, error) {
 	var b bytes.Buffer
 	b.WriteRune('{')
 	first := true
-	err := m.Range(func(k K, v V) error {
+	for k, v := range m.All {
 		if !first {
 			// Separating comma.
 			b.WriteRune(',')
@@ -294,19 +329,15 @@ func (m *Map[K, V]) MarshalJSON() ([]byte, error) {
 		first = false
 		bk, err := json.Marshal(k)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		b.Write(bk)
 		b.WriteRune(':')
 		bv, err := json.Marshal(v)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		b.Write(bv)
-		return nil
-	})
-	if err != nil {
-		return nil, err
 	}
 	b.WriteRune('}')
 	return b.Bytes(), nil
@@ -319,20 +350,15 @@ func (m *Map[K, V]) MarshalYAML() (any, error) {
 		Kind: yaml.MappingNode,
 		Tag:  "!!map",
 	}
-	err := m.Range(func(k K, v V) error {
+	for k, v := range m.All {
 		nk, nv := new(yaml.Node), new(yaml.Node)
 		if err := nk.Encode(k); err != nil {
-			return err
+			return nil, err
 		}
 		if err := nv.Encode(v); err != nil {
-			return err
+			return nil, err
 		}
 		n.Content = append(n.Content, nk, nv)
-		return nil
-	})
-
-	if err != nil {
-		return nil, err
 	}
 	return n, nil
 }
@@ -401,23 +427,22 @@ func (m *Map[K, V]) UnmarshalYAML(n *yaml.Node) error {
 // assertable to V.
 func AssertValues[V any](m *MapSA) (*Map[string, V], error) {
 	msv := NewMap[string, V](m.Len())
-	return msv, m.Range(func(k string, v any) error {
+	for k, v := range m.All {
 		t, ok := v.(V)
 		if !ok {
-			return fmt.Errorf("value for key %q (type %T) is not assertable to %T", k, v, t)
+			return msv, fmt.Errorf("value for key %q (type %T) is not assertable to %T", k, v, t)
 		}
 		msv.Set(k, t)
-		return nil
-	})
+	}
+	return msv, nil
 }
 
 // TransformValues converts a map with V1 values into a map with V2 values by
 // running each value through a function.
 func TransformValues[K comparable, V1, V2 any](m *Map[K, V1], f func(V1) V2) *Map[K, V2] {
 	m2 := NewMap[K, V2](m.Len())
-	m.Range(func(k K, v V1) error {
+	for k, v := range m.All {
 		m2.Set(k, f(v))
-		return nil
-	})
+	}
 	return m2
 }

--- a/ordered/map_test.go
+++ b/ordered/map_test.go
@@ -2,9 +2,11 @@ package ordered
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gopkg.in/yaml.v3"
 )
 
@@ -834,5 +836,95 @@ func TestMapMarshalJSON(t *testing.T) {
 	want := `{"key":"value","molehill":"large","switch":true,"count":42,"fader":2.71828,"slicey":[5,6,7,8]}`
 	if diff := cmp.Diff(string(got), want); diff != "" {
 		t.Errorf("src.MarshalJSON() output diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestMapAll(t *testing.T) {
+	t.Parallel()
+
+	want := []TupleSA{
+		{Key: "key", Value: "value"},
+		{Key: "molehill", Value: "large"},
+		{Key: "switch", Value: true},
+		{Key: "count", Value: 42},
+		{Key: "fader", Value: 2.71828},
+		{Key: "slicey", Value: []any{5, 6, 7, 8}},
+	}
+	m := MapFromItems(want...)
+
+	var got []TupleSA
+	for k, v := range m.All {
+		got = append(got, TupleSA{Key: k, Value: v})
+	}
+
+	if diff := cmp.Diff(got, want, cmpopts.IgnoreUnexported(TupleSA{})); diff != "" {
+		t.Errorf("m.All items ranged diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestMapAllBreak(t *testing.T) {
+	t.Parallel()
+
+	in := []TupleSA{
+		{Key: "key", Value: "value"},
+		{Key: "molehill", Value: "large"},
+		{Key: "switch", Value: true},
+		{Key: "count", Value: 42},
+		{Key: "fader", Value: 2.71828},
+		{Key: "slicey", Value: []any{5, 6, 7, 8}},
+	}
+	m := MapFromItems(in...)
+
+	var got []TupleSA
+	for k, v := range m.All {
+		if k == "count" {
+			break
+		}
+		got = append(got, TupleSA{Key: k, Value: v})
+	}
+
+	want := in[:3]
+	if diff := cmp.Diff(got, want, cmpopts.IgnoreUnexported(TupleSA{})); diff != "" {
+		t.Errorf("m.All items ranged diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestMapKeys(t *testing.T) {
+	t.Parallel()
+
+	m := MapFromItems(
+		TupleSA{Key: "key", Value: "value"},
+		TupleSA{Key: "molehill", Value: "large"},
+		TupleSA{Key: "switch", Value: true},
+		TupleSA{Key: "count", Value: 42},
+		TupleSA{Key: "fader", Value: 2.71828},
+		TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+	)
+
+	got := slices.Collect(m.Keys)
+	want := []string{"key", "molehill", "switch", "count", "fader", "slicey"}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("slices.Collect(m.Keys) diff (-got +want):\n%s", diff)
+	}
+}
+
+func TestMapValues(t *testing.T) {
+	t.Parallel()
+
+	m := MapFromItems(
+		TupleSA{Key: "key", Value: "value"},
+		TupleSA{Key: "molehill", Value: "large"},
+		TupleSA{Key: "switch", Value: true},
+		TupleSA{Key: "count", Value: 42},
+		TupleSA{Key: "fader", Value: 2.71828},
+		TupleSA{Key: "slicey", Value: []any{5, 6, 7, 8}},
+	)
+
+	got := slices.Collect(m.Values)
+	want := []any{"value", "large", true, 42, 2.71828, []any{5, 6, 7, 8}}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("slices.Collect(m.Values) diff (-got +want):\n%s", diff)
 	}
 }

--- a/ordered/unmarshal.go
+++ b/ordered/unmarshal.go
@@ -304,7 +304,7 @@ func (m *Map[K, V]) decodeInto(target any) error {
 
 		valueType := mapType.Elem()
 		var warns []error
-		if err := tm.Range(func(k string, v any) error {
+		for k, v := range tm.All {
 			nv := reflect.New(valueType)
 			err := Unmarshal(v, nv.Interface())
 			if w := warning.As(err); w != nil {
@@ -314,9 +314,6 @@ func (m *Map[K, V]) decodeInto(target any) error {
 			}
 
 			targetValue.SetMapIndex(reflect.ValueOf(k), nv.Elem())
-			return nil
-		}); err != nil {
-			return err
 		}
 		return warning.Wrap(warns...)
 
@@ -410,13 +407,12 @@ func (m *Map[K, V]) decodeInto(target any) error {
 	// Copy all values that weren't non-inline fields into a temporary map.
 	// This is just to avoid mutating tm.
 	temp := NewMap[string, any](tm.Len())
-	tm.Range(func(k string, v any) error {
+	for k, v := range tm.All {
 		if _, outline := outlineKeys[k]; outline {
-			return nil
+			continue
 		}
 		temp.Set(k, v)
-		return nil
-	})
+	}
 
 	// If the inline map contains nothing, then don't bother setting it.
 	if temp.Len() == 0 {
@@ -453,7 +449,7 @@ func (m *Map[K, V]) UnmarshalOrdered(src any) error {
 	}
 
 	var warns []error
-	if err := tsrc.Range(func(k string, v any) error {
+	for k, v := range tsrc.All {
 		var dv V
 		err := Unmarshal(v, &dv)
 		if w := warning.As(err); w != nil {
@@ -462,9 +458,6 @@ func (m *Map[K, V]) UnmarshalOrdered(src any) error {
 			return fmt.Errorf("unmarshaling value for key %q: %w", k, err)
 		}
 		tm.Set(k, dv)
-		return nil
-	}); err != nil {
-		return err
 	}
 	return warning.Wrap(warns...)
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -118,7 +118,7 @@ func (p *Pipeline) Interpolate(interpolationEnv InterpolationEnv, preferRuntimeE
 // be interpolated into later environment variables, we also add the results
 // to interpolationEnv, making the input ordering of p.Env potentially important.
 func (p *Pipeline) interpolateEnvBlock(interpolationEnv InterpolationEnv, preferRuntimeEnv bool) error {
-	return p.Env.Range(func(k, v string) error {
+	for k, v := range p.Env.All {
 		// We interpolate both keys and values.
 		intk, err := interpolate.Interpolate(interpolationEnv, k)
 		if err != nil {
@@ -137,7 +137,6 @@ func (p *Pipeline) interpolateEnvBlock(interpolationEnv InterpolationEnv, prefer
 		if _, exists := interpolationEnv.Get(intk); !(preferRuntimeEnv && exists) {
 			interpolationEnv.Set(intk, intv)
 		}
-
-		return nil
-	})
+	}
+	return nil
 }

--- a/plugins.go
+++ b/plugins.go
@@ -26,8 +26,8 @@ func (p *Plugins) UnmarshalOrdered(o any) error {
 	// Whether processing one big map, or a sequence of small maps, the central
 	// part remains the same.
 	// Parse each "key: value" as "name: config", then append in order.
-	unmarshalMap := func(m *ordered.MapSA) error {
-		return m.Range(func(k string, v any) error {
+	unmarshalMap := func(m *ordered.MapSA) {
+		for k, v := range m.All {
 			// ToMapRecursive demolishes any ordering within the plugin config.
 			// This is needed because the backend likes to reorder the keys,
 			// and for signing we need the JSON form to be stable.
@@ -36,8 +36,7 @@ func (p *Plugins) UnmarshalOrdered(o any) error {
 				Config: ordered.ToMapRecursive(v),
 			}
 			*p = append(*p, plugin)
-			return nil
-		})
+		}
 	}
 
 	switch o := o.(type) {
@@ -55,9 +54,7 @@ func (p *Plugins) UnmarshalOrdered(o any) error {
 				// plugins:
 				//   - plugin#1.0.0:
 				//       config: config, etc
-				if err := unmarshalMap(ct); err != nil {
-					return err
-				}
+				unmarshalMap(ct)
 
 			case string:
 				// Less typical, but supported:
@@ -83,9 +80,7 @@ func (p *Plugins) UnmarshalOrdered(o any) error {
 		//     config: config, etc
 		//   otherplugin#2.0.0:
 		//     etc
-		if err := unmarshalMap(o); err != nil {
-			return err
-		}
+		unmarshalMap(o)
 
 	default:
 		return fmt.Errorf("unmarshaling plugins: got %T, want []any or *ordered.Map[string, any]", o)

--- a/secrets.go
+++ b/secrets.go
@@ -26,7 +26,7 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 
 	case *ordered.Map[string, any]:
 		// Handle map syntax: {"ENV_VAR": "SECRET_KEY"}
-		return o.Range(func(envVar string, secretKeyVal any) error {
+		for envVar, secretKeyVal := range o.All {
 			secretKey, ok := secretKeyVal.(string)
 			if !ok {
 				return fmt.Errorf("unmarshaling secrets: secret key must be a string, but was %T", secretKeyVal)
@@ -43,8 +43,8 @@ func (s *Secrets) UnmarshalOrdered(o any) error {
 				EnvironmentVariable: envVar,
 			}
 			*s = append(*s, secret)
-			return nil
-		})
+		}
+		return nil
 
 	case []any:
 		for _, c := range o {

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -337,7 +337,7 @@ func TestSecretsUnmarshalEmptyMap(t *testing.T) {
 		t.Fatalf("ordered.Unmarshal() error = %v", err)
 	}
 
-	if secrets != nil && len(secrets) != 0 {
+	if len(secrets) != 0 {
 		t.Errorf("Expected empty secrets, got %v", secrets)
 	}
 }

--- a/step_command_checkout.go
+++ b/step_command_checkout.go
@@ -319,10 +319,9 @@ func cloneInlineValue(v any) any {
 			return (*ordered.MapSA)(nil)
 		}
 		out := ordered.NewMap[string, any](v.Len())
-		_ = v.Range(func(k string, vv any) error {
+		for k, vv := range v.All {
 			out.Set(k, cloneInlineValue(vv))
-			return nil
-		})
+		}
 		return out
 
 	default:

--- a/step_command_matrix.go
+++ b/step_command_matrix.go
@@ -351,7 +351,7 @@ func (maw *MatrixAdjustmentWith) UnmarshalOrdered(o any) error {
 	case *ordered.MapSA:
 		// A map of dimension key -> dimension value. (Tuple of dimension value
 		// selections.)
-		return src.Range(func(k string, v any) error {
+		for k, v := range src.All {
 			switch vt := v.(type) {
 			case bool, int, string:
 				(*maw)[k] = fmt.Sprint(vt)
@@ -359,8 +359,8 @@ func (maw *MatrixAdjustmentWith) UnmarshalOrdered(o any) error {
 			default:
 				return fmt.Errorf("unsupported value type %T in key %q for MatrixAdjustmentsWith", v, k)
 			}
-			return nil
-		})
+		}
+		return nil
 
 	default:
 		return fmt.Errorf("unsupported src type for MatrixAdjustmentsWith: %T", o)


### PR DESCRIPTION
### What

Add iterator methods (functions that can be ranged over in a for loop, starting with Go 1.23): `All`, `Keys`, `Values`.

Deprecate `Range`.

### Why

`for k, v := range m.All { ... }` looks much nicer than `if err := m.Range(func(k K, v V) error { ... }); err != nil { return err }`, and can do all the same things. It also makes `ordered.Map` usable with `slices` and `maps` functions, e.g. a non-recursive conversion to a regular map is just `maps.Collect(m.All)`.